### PR TITLE
Improve chain sync and mempool performance for AddOgmiosServices consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,20 @@ The `OgmiosWorker` is a background service that demonstrates how **OgmiosDotnetC
 - **Resumes blockchain synchronization**: Starts synchronizing from the last known point in the blockchain.
 - **Continuously listens for updates**: Monitors the Cardano node for real-time updates and processes new blocks as they are received.
 
-### Services Used by OgmiosWorker:
+### Services registered by `AddOgmiosServices()`
 
-- **IInteractionContextFactory**: Responsible for establishing and managing WebSocket connections to the Cardano node.
-- **IChainSynchronizationClientService**: Handles the synchronization of blockchain data, ensuring that the latest blocks and chain state are processed based on the starting point configuration.
-- **IMemoryPoolMonitoringService**: Provides functionality to monitor and read memory pool transaction data.
+- **IInteractionContextFactory**: WebSocket connections to Ogmios (use separate contexts per protocol).
+- **IChainSynchronizationClientService**: Pipelined chain sync; blocks delivered via `IChainSynchronizationMessageHandlers`.
+- **IMemoryPoolMonitoringService**: Low-level mempool RPC methods.
+- **IMemoryPoolMonitoringClientService**: High-throughput acquire → drain → repeat loop with `IMemoryPoolMonitoringMessageHandlers`.
+
+### Performance notes
+
+- Keep `IChainSynchronizationMessageHandlers` and `IMemoryPoolMonitoringMessageHandlers` fast; enqueue heavy work to background workers.
+- Use `IMemoryPoolMonitoringClientService.RunAsync` or `MemoryPoolMonitoringExtensions.MonitorAsync` to drain full snapshots.
+- Do not share one WebSocket between chain sync and mempool monitoring.
+
+See [Chain Synchronization](src/Ogmios.Services/ChainSynchronization/docs/README.md) and [Memory Pool Monitoring](src/Ogmios.Services/MemoryPoolMonitoring/docs/README.md) for details.
 
 ### 4. Saving Data to an In-Memory PostgreSQL Database
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ The `OgmiosWorker` is a background service that demonstrates how **OgmiosDotnetC
 
 ### Performance notes
 
-- Keep `IChainSynchronizationMessageHandlers` and `IMemoryPoolMonitoringMessageHandlers` fast; enqueue heavy work to background workers.
-- Use `IMemoryPoolMonitoringClientService.RunAsync` or `MemoryPoolMonitoringExtensions.MonitorAsync` to drain full snapshots.
-- Do not share one WebSocket between chain sync and mempool monitoring.
+- **Replenish `nextBlock` before handler execution** so the pipelined window stays full during slow handlers
+- **Ordered handler queues** (capacity 2000) for chain sync and mempool orchestrator — parsing/RPC continues while handlers run
+- **Pre-serialized mempool RPC bodies** on the hot path (acquire, nextTransaction, size, release)
+- **Zero-allocation `nextBlock` requests** when no custom JSON-RPC id is required
+- **Single-copy WebSocket receive** for chain sync frames
 
 See [Chain Synchronization](src/Ogmios.Services/ChainSynchronization/docs/README.md) and [Memory Pool Monitoring](src/Ogmios.Services/MemoryPoolMonitoring/docs/README.md) for details.
 

--- a/src/Ogmios.Domain/Ogmios.Domain.csproj
+++ b/src/Ogmios.Domain/Ogmios.Domain.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Ogmios.Domain</RootNamespace>
 
    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.14.0.1</Version>
+    <Version>6.14.0.2</Version>
     <Authors>Dave B</Authors>
     <PackageId>OgmiosDotnetClient.Domain</PackageId>
     <Description>Domain core for OgmiosDotnetClient.</Description>

--- a/src/Ogmios.Example.Worker/Examples/MemPoolMonitoringExample.cs
+++ b/src/Ogmios.Example.Worker/Examples/MemPoolMonitoringExample.cs
@@ -1,17 +1,16 @@
-using Corvus.Json;
+using Generated;
 using Ogmios.Domain;
 using Ogmios.Example.Database.Services;
-using Ogmios.Services.InteractionContext;
 using Ogmios.Services.MemoryPoolMonitoring;
 
 namespace Ogmios.Example.Worker.Examples;
 
 /// <summary>
-/// Demonstrates the Memory Pool (Mempool) Monitoring capabilities of Ogmios.
-/// Shows how to acquire a mempool snapshot, query transactions, and monitor for new transactions.
+/// Demonstrates high-throughput mempool monitoring via <see cref="IMemoryPoolMonitoringClientService"/>.
+/// Uses acquire → drain-all → repeat with optional transaction deduplication.
 /// </summary>
 public class MemPoolMonitoringExample(
-    IMemoryPoolMonitoringService memoryPoolMonitoringService,
+    IMemoryPoolMonitoringClientService memoryPoolMonitoringClientService,
     ITransactionService transactionService) : IExample
 {
     public string Name => "MemPool Monitoring";
@@ -19,73 +18,48 @@ public class MemPoolMonitoringExample(
     public async Task ExecuteAsync(InteractionContext context, OgmiosConfiguration ogmiosConfiguration, CancellationToken cancellationToken)
     {
         Console.WriteLine("\u001b[33m--- MemPool Monitoring Demonstration ---\u001b[0m");
+        Console.WriteLine("\u001b[36m[MemPool] Starting high-throughput mempool monitoring...\u001b[0m");
 
-        Console.WriteLine($"\u001b[36m[MemPool] Acquiring mempool snapshot...\u001b[0m");
+        var handlers = new MempoolMonitoringHandlers(transactionService);
 
-        while (!cancellationToken.IsCancellationRequested)
+        try
         {
-            Console.WriteLine("\u001b[33m[MemPool] Waiting for changes in the mempool snapshot...\u001b[0m");
-
-            var mempoolAcquired = await memoryPoolMonitoringService.AcquireMempoolAsync(context, cancellationToken);
-            var mempoolSizeAndCapacity = await memoryPoolMonitoringService.SizeOfMempoolAsync(context, cancellationToken);
-
-            Console.WriteLine($"\u001b[32m[MemPool] Maximum capacity (bytes): {mempoolSizeAndCapacity.MaxCapacity.Bytes}\u001b[0m");
-            Console.WriteLine($"\u001b[32m[MemPool] Current size (bytes): {mempoolSizeAndCapacity.CurrentSize.Bytes}\u001b[0m");
-
-            var nextTransaction = await memoryPoolMonitoringService.NextTransactionAsync(context, cancellationToken);
-            if (nextTransaction.IsNullOrUndefined())
-            {
-                Console.WriteLine($"\u001b[33m[MemPool] No transactions in mempool snapshot.\u001b[0m");
-                continue;
-            }
-
-            var nextTransactionEntity = nextTransaction.AsTransaction;
-            Console.WriteLine($"\u001b[32m[MemPool] Transaction Id: {nextTransactionEntity.Id}\u001b[0m");
-            Console.WriteLine($"\u001b[32m[MemPool] Transaction Fee: {nextTransactionEntity.Fee}\u001b[0m");
-
-            if (nextTransactionEntity.Metadata.IsNotNullOrUndefined())
-            {
-                var formattedLabels = string.Join("\n", nextTransactionEntity.Metadata.Labels.Select(label =>
-                    $"\u001b[32m  Key: {label.Key}\n  Value: {label.Value}\u001b[0m"));
-                Console.WriteLine($"\u001b[32m[MemPool] Transaction Metadata:\n{formattedLabels}\u001b[0m");
-            }
-
-            Console.WriteLine($"\u001b[32m[MemPool] Transaction Inputs: {nextTransactionEntity.Inputs.Count()}\u001b[0m");
-            Console.WriteLine($"\u001b[32m[MemPool] Transaction Outputs: {nextTransactionEntity.Outputs.Count()}\u001b[0m");
-
-            // Check if a specific transaction exists in the mempool
-            var sampleTxId = "eddc4a21f5da916a3f8b0a8c1dc6cbeec790d058ce8ecb9390f326489768bbf1";
-            var hasTransaction = await memoryPoolMonitoringService.HasTransactionAsync(context, sampleTxId, cancellationToken);
-            Console.WriteLine($"\u001b[32m[MemPool] Transaction {sampleTxId[..16]}... exists in snapshot?: {hasTransaction.Result}\u001b[0m");
-
-            // Save transaction to database
-            await SaveTransactionAsync(nextTransaction.AsTransaction);
-
+            await memoryPoolMonitoringClientService.RunAsync(
+                context,
+                handlers,
+                cancellationToken,
+                new MemoryPoolMonitoringClientOptions { DeduplicateTransactions = true });
+        }
+        finally
+        {
             if (cancellationToken.IsCancellationRequested)
             {
-                Console.WriteLine($"\u001b[36m[MemPool] Releasing mempool snapshot...\u001b[0m");
-                await memoryPoolMonitoringService.ReleaseMempoolAsync(context, cancellationToken);
-                await memoryPoolMonitoringService.ShutdownAsync(context, cancellationToken);
-                Console.WriteLine($"\u001b[32m[MemPool] Mempool released and shutdown complete.\u001b[0m");
+                await memoryPoolMonitoringClientService.ShutdownAsync(context, CancellationToken.None);
             }
         }
 
         Console.WriteLine("\u001b[33m--- MemPool Monitoring Demonstration Complete ---\u001b[0m");
     }
 
-    private async Task SaveTransactionAsync(Generated.Transaction transaction)
+    private sealed class MempoolMonitoringHandlers(ITransactionService transactionService) : IMemoryPoolMonitoringMessageHandlers
     {
-        var transactionId = (string)transaction.Id;
-        var existingTransaction = await transactionService.GetTransactionAsync(transactionId);
-
-        if (existingTransaction is not null)
+        public Task OnSnapshotAcquiredAsync(Generated.Slot slot, CancellationToken cancellationToken)
         {
-            Console.WriteLine($"\u001b[33m[MemPool] Transaction already exists in database.\u001b[0m");
-            return;
+            Console.WriteLine($"\u001b[32m[MemPool] Snapshot acquired at slot {slot}\u001b[0m");
+            return Task.CompletedTask;
         }
 
-        Console.WriteLine($"\u001b[36m[MemPool] Saving transaction to database...\u001b[0m");
-        await transactionService.CreateTransactionAsync(transaction);
-        Console.WriteLine($"\u001b[32m[MemPool] Transaction successfully saved to database.\u001b[0m");
+        public async Task OnTransactionAsync(Generated.Transaction transaction, CancellationToken cancellationToken)
+        {
+            var transactionId = (string)transaction.Id;
+            var existing = await transactionService.GetTransactionAsync(transactionId).ConfigureAwait(false);
+            if (existing is not null)
+            {
+                return;
+            }
+
+            await transactionService.CreateTransactionAsync(transaction).ConfigureAwait(false);
+            Console.WriteLine($"\u001b[32m[MemPool] Saved transaction {transactionId[..16]}...\u001b[0m");
+        }
     }
 }

--- a/src/Ogmios.Schema/Ogmios.Schema.csproj
+++ b/src/Ogmios.Schema/Ogmios.Schema.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Ogmios.Schema</RootNamespace>
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.14.0.1</Version>
+    <Version>6.14.0.2</Version>
     <Authors>Dave B</Authors>
     <PackageId>OgmiosDotnetClient.Schema</PackageId>
     <Description>Versioned auto-generated idiomatic types as a typed representation of Ogmios schema.</Description>

--- a/src/Ogmios.Services/ChainSynchronization/BlockService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/BlockService.cs
@@ -60,10 +60,6 @@ public class BlockService(IWebSocketService webSocketService) : IBlockService
                 if (block.HasProperty("height") && block.TryGetProperty("height", out var height) && block.HasProperty("type") && block.TryGetProperty("type", out var type))
                 {
                     var blocktype = (string)type.AsString ?? "Unknown type";
-                    if (height.AsNumber % 1000 == 0)
-                    {
-                        Console.WriteLine($"\u001b[32m {height}\u001b[0m");
-                    }
                     await messageHandlers.RollForwardHandler(block, blocktype, result.Instance.Result.AsRollForward.Tip);
                 }
                 break;

--- a/src/Ogmios.Services/ChainSynchronization/BlockService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/BlockService.cs
@@ -1,25 +1,32 @@
 using System.Text;
+using System.Threading.Channels;
 using Corvus.Json;
+using Generated;
+using Microsoft.Extensions.Logging;
 using Ogmios.Domain;
 
 namespace Ogmios.Services.ChainSynchronization;
 
-public class BlockService(IWebSocketService webSocketService) : IBlockService
+public class BlockService(IWebSocketService webSocketService, ILogger<BlockService>? logger = null) : IBlockService
 {
+    private readonly ILogger<BlockService>? _logger = logger;
+    private static readonly byte[] NextBlockMessage = Encoding.UTF8.GetBytes("{\"jsonrpc\":\"2.0\",\"method\":\"nextBlock\"}");
     private static readonly byte[] NextBlockPrefix = Encoding.UTF8.GetBytes("{\"jsonrpc\":\"2.0\",\"method\":\"nextBlock\",\"id\":\"");
     private static readonly byte[] NextBlockSuffix = Encoding.UTF8.GetBytes("\"}");
 
     public Task GetNextBlockAsync(Domain.InteractionContext context, MirrorOptions? options = null)
     {
-        var requestId = options?.Id ?? string.Empty;
-        var idBytes = Encoding.UTF8.GetBytes(requestId);
-        var message = new byte[NextBlockPrefix.Length + idBytes.Length + NextBlockSuffix.Length];
+        if (options?.Id is { Length: > 0 } requestId)
+        {
+            var idBytes = Encoding.UTF8.GetBytes(requestId);
+            var message = new byte[NextBlockPrefix.Length + idBytes.Length + NextBlockSuffix.Length];
+            NextBlockPrefix.CopyTo(message, 0);
+            idBytes.CopyTo(message, NextBlockPrefix.Length);
+            NextBlockSuffix.CopyTo(message, NextBlockPrefix.Length + idBytes.Length);
+            return webSocketService.SendMessageAsync(message, context.Socket);
+        }
 
-        NextBlockPrefix.CopyTo(message, 0);
-        idBytes.CopyTo(message, NextBlockPrefix.Length);
-        NextBlockSuffix.CopyTo(message, NextBlockPrefix.Length + idBytes.Length);
-
-        return webSocketService.SendMessageAsync(message, context.Socket);
+        return webSocketService.SendMessageAsync(NextBlockMessage, context.Socket);
     }
 
     public async Task HandleNextBlockAsync(string response, IChainSynchronizationMessageHandlers messageHandlers)
@@ -30,7 +37,7 @@ public class BlockService(IWebSocketService webSocketService) : IBlockService
         }
 
         var result = ParsedValue<Generated.Ogmios.NextBlockResponse>.Parse(response);
-        await ProcessParsedBlockAsync(result, messageHandlers);
+        await DispatchParsedBlockAsync(result, messageHandlers).ConfigureAwait(false);
     }
 
     public async Task HandleNextBlockAsync(ReadOnlyMemory<byte> utf8Response, IChainSynchronizationMessageHandlers messageHandlers)
@@ -41,32 +48,81 @@ public class BlockService(IWebSocketService webSocketService) : IBlockService
         }
 
         var result = ParsedValue<Generated.Ogmios.NextBlockResponse>.Parse(utf8Response);
-        await ProcessParsedBlockAsync(result, messageHandlers);
+        await DispatchParsedBlockAsync(result, messageHandlers).ConfigureAwait(false);
     }
 
-    private static async Task ProcessParsedBlockAsync(ParsedValue<Generated.Ogmios.NextBlockResponse> result, IChainSynchronizationMessageHandlers messageHandlers)
+    public async ValueTask EnqueueBlockHandlersAsync(ReadOnlyMemory<byte> utf8Response, ChannelWriter<ChainSyncBlockWork> writer, CancellationToken cancellationToken = default)
     {
-        result.Instance.Result.TryGetProperty("direction", out var direction);
+        if (utf8Response.Length == 0)
+        {
+            return;
+        }
+
+        var result = ParsedValue<Generated.Ogmios.NextBlockResponse>.Parse(utf8Response);
+        await EnqueueParsedBlockAsync(result, writer, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task DispatchParsedBlockAsync(ParsedValue<Generated.Ogmios.NextBlockResponse> result, IChainSynchronizationMessageHandlers messageHandlers)
+    {
+        if (!TryCreateBlockWork(result, out var work))
+        {
+            return;
+        }
+
+        switch (work)
+        {
+            case ChainSyncRollBackwardWork rollback:
+                await messageHandlers.RollBackwardHandler(rollback.Point, rollback.Tip).ConfigureAwait(false);
+                break;
+            case ChainSyncRollForwardWork forward:
+                await messageHandlers.RollForwardHandler(forward.Block, forward.BlockType, forward.Tip).ConfigureAwait(false);
+                break;
+        }
+    }
+
+    private async ValueTask EnqueueParsedBlockAsync(
+        ParsedValue<Generated.Ogmios.NextBlockResponse> result,
+        ChannelWriter<ChainSyncBlockWork> writer,
+        CancellationToken cancellationToken)
+    {
+        if (!TryCreateBlockWork(result, out var work))
+        {
+            return;
+        }
+
+        await writer.WriteAsync(work, cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool TryCreateBlockWork(ParsedValue<Generated.Ogmios.NextBlockResponse> result, out ChainSyncBlockWork work)
+    {
+        work = null!;
+
+        if (!result.Instance.Result.TryGetProperty("direction", out var direction))
+        {
+            return false;
+        }
 
         switch ((string)direction.AsString)
         {
             case "backward":
                 var rollBackward = result.Instance.Result.AsRollBackward;
-                await messageHandlers.RollBackwardHandler(rollBackward.Point, rollBackward.Tip);
-                break;
+                work = new ChainSyncRollBackwardWork(rollBackward.Point, rollBackward.Tip);
+                return true;
 
             case "forward":
                 var block = result.Instance.Result.AsRollForward.Block;
-                if (block.HasProperty("height") && block.TryGetProperty("height", out var height) && block.HasProperty("type") && block.TryGetProperty("type", out var type))
+                if (block.HasProperty("height") && block.TryGetProperty("height", out _) && block.HasProperty("type") && block.TryGetProperty("type", out var type))
                 {
                     var blocktype = (string)type.AsString ?? "Unknown type";
-                    await messageHandlers.RollForwardHandler(block, blocktype, result.Instance.Result.AsRollForward.Tip);
+                    work = new ChainSyncRollForwardWork(block, blocktype, result.Instance.Result.AsRollForward.Tip);
+                    return true;
                 }
-                break;
+
+                return false;
 
             default:
-                Console.WriteLine("Unknown direction or unsupported block direction.");
-                break;
+                _logger?.LogDebug("Unknown or unsupported block direction: {Direction}", direction.AsString);
+                return false;
         }
     }
 }

--- a/src/Ogmios.Services/ChainSynchronization/BlockService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/BlockService.cs
@@ -1,15 +1,25 @@
+using System.Text;
 using Corvus.Json;
 using Ogmios.Domain;
-
 
 namespace Ogmios.Services.ChainSynchronization;
 
 public class BlockService(IWebSocketService webSocketService) : IBlockService
 {
+    private static readonly byte[] NextBlockPrefix = Encoding.UTF8.GetBytes("{\"jsonrpc\":\"2.0\",\"method\":\"nextBlock\",\"id\":\"");
+    private static readonly byte[] NextBlockSuffix = Encoding.UTF8.GetBytes("\"}");
+
     public Task GetNextBlockAsync(Domain.InteractionContext context, MirrorOptions? options = null)
     {
-        var nextBlockRequest = Generated.Ogmios.NextBlock.Create(jsonrpc: Generated.Ogmios.NextBlock.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.NextBlock.MethodEntity.EnumValues.NextBlock, id: options?.Id ?? string.Empty);
-        return webSocketService.SendMessageAsync(nextBlockRequest.AsJsonElement.ToString(), context.Socket);
+        var requestId = options?.Id ?? string.Empty;
+        var idBytes = Encoding.UTF8.GetBytes(requestId);
+        var message = new byte[NextBlockPrefix.Length + idBytes.Length + NextBlockSuffix.Length];
+
+        NextBlockPrefix.CopyTo(message, 0);
+        idBytes.CopyTo(message, NextBlockPrefix.Length);
+        NextBlockSuffix.CopyTo(message, NextBlockPrefix.Length + idBytes.Length);
+
+        return webSocketService.SendMessageAsync(message, context.Socket);
     }
 
     public async Task HandleNextBlockAsync(string response, IChainSynchronizationMessageHandlers messageHandlers)

--- a/src/Ogmios.Services/ChainSynchronization/ChainSyncBlockWork.cs
+++ b/src/Ogmios.Services/ChainSynchronization/ChainSyncBlockWork.cs
@@ -1,0 +1,24 @@
+using Generated;
+
+namespace Ogmios.Services.ChainSynchronization;
+
+/// <summary>
+/// Ordered block event dispatched to <see cref="IChainSynchronizationMessageHandlers"/>.
+/// </summary>
+public abstract class ChainSyncBlockWork;
+
+public sealed class ChainSyncRollForwardWork(Block block, string blockType, Tip tip) : ChainSyncBlockWork
+{
+    public Block Block { get; } = block;
+
+    public string BlockType { get; } = blockType;
+
+    public Tip Tip { get; } = tip;
+}
+
+public sealed class ChainSyncRollBackwardWork(Generated.Ogmios.PointOrOrigin point, Generated.Ogmios.TipOrOrigin tip) : ChainSyncBlockWork
+{
+    public Generated.Ogmios.PointOrOrigin Point { get; } = point;
+
+    public Generated.Ogmios.TipOrOrigin Tip { get; } = tip;
+}

--- a/src/Ogmios.Services/ChainSynchronization/ChainSynchronizationClientService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/ChainSynchronizationClientService.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Collections.Concurrent;
 using Ogmios.Domain;
@@ -10,7 +12,7 @@ namespace Ogmios.Services.ChainSynchronization
         /// The active session's message queue. Re-created on every <see cref="ResumeAsync"/>
         /// so a new session never consumes messages queued by a previous session.
         /// </summary>
-        public BlockingCollection<(byte[], Domain.InteractionContext)> MessageQueue { get; private set; } = new(boundedCapacity: 1000);
+        public BlockingCollection<PooledWebSocketMessage> MessageQueue { get; private set; } = new(boundedCapacity: 1000);
 
         private readonly IChainSynchronizationMessageHandlers _messageHandlers = messageHandlers ?? throw new ArgumentNullException(nameof(messageHandlers));
         private readonly IIntersectionService _intersectionService = intersectionService ?? throw new ArgumentNullException(nameof(intersectionService));
@@ -28,49 +30,61 @@ namespace Ogmios.Services.ChainSynchronization
 
         private async Task ResumeListeningAsync(
             Domain.InteractionContext interactionContext,
-            BlockingCollection<(byte[], Domain.InteractionContext)> messageQueue,
+            BlockingCollection<PooledWebSocketMessage> messageQueue,
             CancellationToken cancellationToken)
         {
-            var buffer = new byte[65536]; // 64 KB buffer to reduce fragmented reads for large Cardano blocks
+            var buffer = ArrayPool<byte>.Shared.Rent(65536);
             using var messageStream = new MemoryStream();
 
-            while (!cancellationToken.IsCancellationRequested && interactionContext.Socket.State == WebSocketState.Open)
+            try
             {
-                try
+                while (!cancellationToken.IsCancellationRequested && interactionContext.Socket.State == WebSocketState.Open)
                 {
-                    var result = await interactionContext.Socket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
-
-                    if (result.MessageType == WebSocketMessageType.Text)
+                    try
                     {
-                        messageStream.Write(buffer, 0, result.Count);
+                        var receiveBuffer = new ArraySegment<byte>(buffer, 0, Math.Min(buffer.Length, 65536));
+                        var result = await interactionContext.Socket.ReceiveAsync(receiveBuffer, cancellationToken);
 
-                        if (result.EndOfMessage)
+                        if (result.MessageType == WebSocketMessageType.Text)
                         {
-                            var messageBytes = messageStream.ToArray();
-                            messageQueue.Add((messageBytes, interactionContext), cancellationToken);
-                            messageStream.SetLength(0);
+                            messageStream.Write(buffer, 0, result.Count);
+
+                            if (result.EndOfMessage)
+                            {
+                                var messageLength = (int)messageStream.Length;
+                                var messageBuffer = ArrayPool<byte>.Shared.Rent(messageLength);
+                                _ = messageStream.TryGetBuffer(out var streamBuffer);
+                                Buffer.BlockCopy(streamBuffer.Array!, streamBuffer.Offset, messageBuffer, 0, messageLength);
+
+                                messageQueue.Add(new PooledWebSocketMessage(messageBuffer, messageLength, interactionContext), cancellationToken);
+                                messageStream.SetLength(0);
+                            }
+                        }
+                        else if (result.MessageType == WebSocketMessageType.Close)
+                        {
+                            await ShutdownAsync(interactionContext).ConfigureAwait(false);
+                            break;
                         }
                     }
-                    else if (result.MessageType == WebSocketMessageType.Close)
+                    catch (OperationCanceledException)
                     {
-                        await ShutdownAsync(interactionContext).ConfigureAwait(false);
                         break;
                     }
-                }
-                catch (OperationCanceledException)
-                {
-                    break;
-                }
-                catch (WebSocketException webSocketException)
-                {
-                    Console.WriteLine($"WebSocket error: {webSocketException.Message}");
+                    catch (WebSocketException webSocketException)
+                    {
+                        Console.WriteLine($"WebSocket error: {webSocketException.Message}");
 
-                    if (interactionContext.Socket.State != WebSocketState.Open) break;
+                        if (interactionContext.Socket.State != WebSocketState.Open) break;
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.WriteLine($"Unexpected error: {ex.Message}");
+                    }
                 }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Unexpected error: {ex.Message}");
-                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
             }
         }
 
@@ -80,18 +94,39 @@ namespace Ogmios.Services.ChainSynchronization
         }
 
         private async Task ProcessMessagesAsync(
-            BlockingCollection<(byte[], Domain.InteractionContext)> messageQueue,
+            BlockingCollection<PooledWebSocketMessage> messageQueue,
             int maxBlocksPerSecond,
             CancellationToken cancellationToken)
         {
+            var minIntervalBetweenRequests = maxBlocksPerSecond > 0
+                ? TimeSpan.FromSeconds(1.0 / maxBlocksPerSecond)
+                : TimeSpan.Zero;
+            var requestStopwatch = Stopwatch.StartNew();
+
             try
             {
-                foreach (var item in messageQueue.GetConsumingEnumerable(cancellationToken))
+                foreach (var message in messageQueue.GetConsumingEnumerable(cancellationToken))
                 {
-                    var (messageBytes, context) = item;
+                    try
+                    {
+                        await ProcessBlockMessageAsync(message.Memory).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        message.Return();
+                    }
 
-                    await ProcessBlockMessageAsync(messageBytes);
-                    await RequestNextBlockAsync(context);
+                    if (minIntervalBetweenRequests > TimeSpan.Zero)
+                    {
+                        var elapsed = requestStopwatch.Elapsed;
+                        if (elapsed < minIntervalBetweenRequests)
+                        {
+                            await Task.Delay(minIntervalBetweenRequests - elapsed, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+
+                    await RequestNextBlockAsync(message.Context).ConfigureAwait(false);
+                    requestStopwatch.Restart();
                 }
             }
             catch (OperationCanceledException)
@@ -104,11 +139,11 @@ namespace Ogmios.Services.ChainSynchronization
             }
         }
 
-        private async Task ProcessBlockMessageAsync(byte[] messageBytes)
+        private async Task ProcessBlockMessageAsync(ReadOnlyMemory<byte> messageBytes)
         {
             try
             {
-                await _blockService.HandleNextBlockAsync(new ReadOnlyMemory<byte>(messageBytes), _messageHandlers);
+                await _blockService.HandleNextBlockAsync(messageBytes, _messageHandlers).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -118,15 +153,14 @@ namespace Ogmios.Services.ChainSynchronization
 
         public async Task<List<StartingPointConfiguration>> ResumeAsync(List<Domain.InteractionContext> interactionContexts, int maxBlocksPerSecond, int inFlight = 100, CancellationToken cancellationToken = default)
         {
-            // Terminate any previous session first so only one session pumps blocks.
             await ShutdownSessionAsync().ConfigureAwait(false);
 
             CancellationTokenSource sessionCts;
-            BlockingCollection<(byte[], Domain.InteractionContext)> sessionQueue;
+            BlockingCollection<PooledWebSocketMessage> sessionQueue;
             lock (_sessionLock)
             {
                 sessionCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                sessionQueue = new BlockingCollection<(byte[], Domain.InteractionContext)>(boundedCapacity: 1000);
+                sessionQueue = new BlockingCollection<PooledWebSocketMessage>(boundedCapacity: 1000);
                 _sessionCts = sessionCts;
                 MessageQueue = sessionQueue;
                 _sessionContexts = interactionContexts.ToList();
@@ -157,7 +191,7 @@ namespace Ogmios.Services.ChainSynchronization
             {
                 for (int i = 0; i < inFlight; i++)
                 {
-                    await RequestNextBlockAsync(context);
+                    await RequestNextBlockAsync(context).ConfigureAwait(false);
                 }
             }
 
@@ -185,7 +219,6 @@ namespace Ogmios.Services.ChainSynchronization
             try { cts?.Cancel(); }
             catch (ObjectDisposedException) { }
 
-            // Close sockets so a listener blocked inside ReceiveAsync unblocks.
             foreach (var context in contexts)
             {
                 try { await ShutdownAsync(context).ConfigureAwait(false); }
@@ -206,7 +239,7 @@ namespace Ogmios.Services.ChainSynchronization
             try
             {
                 var requestId = Guid.NewGuid();
-                await _blockService.GetNextBlockAsync(interactionContext, new MirrorOptions { Id = requestId.ToString() });
+                await _blockService.GetNextBlockAsync(interactionContext, new MirrorOptions { Id = requestId.ToString() }).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/Ogmios.Services/ChainSynchronization/ChainSynchronizationClientService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/ChainSynchronizationClientService.cs
@@ -1,13 +1,22 @@
+using System.Collections.Concurrent;
 using System.Buffers;
 using System.Diagnostics;
 using System.Net.WebSockets;
-using System.Collections.Concurrent;
+using System.Threading.Channels;
 using Ogmios.Domain;
+using Microsoft.Extensions.Logging;
 
 namespace Ogmios.Services.ChainSynchronization
 {
-    public class ChainSynchronizationClientService(IChainSynchronizationMessageHandlers messageHandlers, IIntersectionService intersectionService, IBlockService blockService) : IChainSynchronizationClientService
+    public class ChainSynchronizationClientService(
+        IChainSynchronizationMessageHandlers messageHandlers,
+        IIntersectionService intersectionService,
+        IBlockService blockService,
+        ILogger<ChainSynchronizationClientService>? logger = null) : IChainSynchronizationClientService
     {
+        private const int HandlerQueueCapacity = 2000;
+        private const int ReceiveBufferSize = 65536;
+
         /// <summary>
         /// The active session's message queue. Re-created on every <see cref="ResumeAsync"/>
         /// so a new session never consumes messages queued by a previous session.
@@ -17,11 +26,13 @@ namespace Ogmios.Services.ChainSynchronization
         private readonly IChainSynchronizationMessageHandlers _messageHandlers = messageHandlers ?? throw new ArgumentNullException(nameof(messageHandlers));
         private readonly IIntersectionService _intersectionService = intersectionService ?? throw new ArgumentNullException(nameof(intersectionService));
         private readonly IBlockService _blockService = blockService ?? throw new ArgumentNullException(nameof(blockService));
+        private readonly ILogger<ChainSynchronizationClientService>? _logger = logger;
 
         private readonly object _sessionLock = new();
         private CancellationTokenSource? _sessionCts;
         private List<Task> _sessionTasks = new();
         private List<Domain.InteractionContext> _sessionContexts = new();
+        private ChannelWriter<ChainSyncBlockWork>? _handlerQueueWriter;
 
         public async Task ResumeListeningAsync(Domain.InteractionContext interactionContext, CancellationToken cancellationToken)
         {
@@ -33,8 +44,9 @@ namespace Ogmios.Services.ChainSynchronization
             BlockingCollection<PooledWebSocketMessage> messageQueue,
             CancellationToken cancellationToken)
         {
-            var buffer = ArrayPool<byte>.Shared.Rent(65536);
-            using var messageStream = new MemoryStream();
+            var receiveScratch = ArrayPool<byte>.Shared.Rent(ReceiveBufferSize);
+            byte[]? messageBuffer = null;
+            var messageLength = 0;
 
             try
             {
@@ -42,22 +54,21 @@ namespace Ogmios.Services.ChainSynchronization
                 {
                     try
                     {
-                        var receiveBuffer = new ArraySegment<byte>(buffer, 0, Math.Min(buffer.Length, 65536));
-                        var result = await interactionContext.Socket.ReceiveAsync(receiveBuffer, cancellationToken);
+                        var result = await interactionContext.Socket.ReceiveAsync(
+                            new ArraySegment<byte>(receiveScratch, 0, ReceiveBufferSize),
+                            cancellationToken).ConfigureAwait(false);
 
                         if (result.MessageType == WebSocketMessageType.Text)
                         {
-                            messageStream.Write(buffer, 0, result.Count);
+                            EnsureMessageCapacity(ref messageBuffer, ref messageLength, result.Count);
+                            Buffer.BlockCopy(receiveScratch, 0, messageBuffer!, messageLength, result.Count);
+                            messageLength += result.Count;
 
                             if (result.EndOfMessage)
                             {
-                                var messageLength = (int)messageStream.Length;
-                                var messageBuffer = ArrayPool<byte>.Shared.Rent(messageLength);
-                                _ = messageStream.TryGetBuffer(out var streamBuffer);
-                                Buffer.BlockCopy(streamBuffer.Array!, streamBuffer.Offset, messageBuffer, 0, messageLength);
-
-                                messageQueue.Add(new PooledWebSocketMessage(messageBuffer, messageLength, interactionContext), cancellationToken);
-                                messageStream.SetLength(0);
+                                messageQueue.Add(new PooledWebSocketMessage(messageBuffer!, messageLength, interactionContext), cancellationToken);
+                                messageBuffer = null;
+                                messageLength = 0;
                             }
                         }
                         else if (result.MessageType == WebSocketMessageType.Close)
@@ -70,31 +81,78 @@ namespace Ogmios.Services.ChainSynchronization
                     {
                         break;
                     }
-                    catch (WebSocketException webSocketException)
+                    catch (WebSocketException ex)
                     {
-                        Console.WriteLine($"WebSocket error: {webSocketException.Message}");
+                        _logger?.LogWarning(ex, "WebSocket error while listening for chain sync messages.");
 
                         if (interactionContext.Socket.State != WebSocketState.Open) break;
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"Unexpected error: {ex.Message}");
+                        _logger?.LogError(ex, "Unexpected error while listening for chain sync messages.");
                     }
                 }
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(buffer);
+                if (messageBuffer is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(messageBuffer);
+                }
+
+                ArrayPool<byte>.Shared.Return(receiveScratch);
             }
+        }
+
+        private static void EnsureMessageCapacity(ref byte[]? messageBuffer, ref int messageLength, int additionalBytes)
+        {
+            var required = messageLength + additionalBytes;
+            if (messageBuffer is not null && required <= messageBuffer.Length)
+            {
+                return;
+            }
+
+            var newCapacity = Math.Max(required, messageBuffer?.Length * 2 ?? ReceiveBufferSize);
+            var newBuffer = ArrayPool<byte>.Shared.Rent(newCapacity);
+
+            if (messageBuffer is not null)
+            {
+                if (messageLength > 0)
+                {
+                    Buffer.BlockCopy(messageBuffer, 0, newBuffer, 0, messageLength);
+                }
+
+                ArrayPool<byte>.Shared.Return(messageBuffer);
+            }
+
+            messageBuffer = newBuffer;
         }
 
         public async Task ProcessMessagesAsync(int maxBlocksPerSecond, CancellationToken cancellationToken)
         {
-            await ProcessMessagesAsync(MessageQueue, maxBlocksPerSecond, cancellationToken).ConfigureAwait(false);
+            var handlerChannel = Channel.CreateBounded<ChainSyncBlockWork>(new BoundedChannelOptions(HandlerQueueCapacity)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                SingleWriter = true
+            });
+
+            var handlerTask = ProcessHandlerQueueAsync(handlerChannel.Reader, cancellationToken);
+
+            try
+            {
+                await ProcessMessagesAsync(MessageQueue, handlerChannel.Writer, maxBlocksPerSecond, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                handlerChannel.Writer.TryComplete();
+                await handlerTask.ConfigureAwait(false);
+            }
         }
 
         private async Task ProcessMessagesAsync(
             BlockingCollection<PooledWebSocketMessage> messageQueue,
+            ChannelWriter<ChainSyncBlockWork> handlerWriter,
             int maxBlocksPerSecond,
             CancellationToken cancellationToken)
         {
@@ -116,14 +174,16 @@ namespace Ogmios.Services.ChainSynchronization
                         }
                     }
 
-                    // Replenish the pipeline before handler work so in-flight requests stay high
-                    // even when RollForwardHandler/RollBackwardHandler is slow.
                     await RequestNextBlockAsync(message.Context).ConfigureAwait(false);
                     requestStopwatch.Restart();
 
                     try
                     {
-                        await ProcessBlockMessageAsync(message.Memory).ConfigureAwait(false);
+                        await _blockService.EnqueueBlockHandlersAsync(message.Memory, handlerWriter, cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogError(ex, "Error enqueueing block handler work.");
                     }
                     finally
                     {
@@ -133,23 +193,45 @@ namespace Ogmios.Services.ChainSynchronization
             }
             catch (OperationCanceledException)
             {
-                Console.WriteLine("Processing cancelled.");
+                _logger?.LogDebug("Chain sync message processing cancelled.");
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error processing messages: {ex.Message}.");
+                _logger?.LogError(ex, "Error processing chain sync messages.");
             }
         }
 
-        private async Task ProcessBlockMessageAsync(ReadOnlyMemory<byte> messageBytes)
+        private async Task ProcessHandlerQueueAsync(ChannelReader<ChainSyncBlockWork> reader, CancellationToken cancellationToken)
         {
             try
             {
-                await _blockService.HandleNextBlockAsync(messageBytes, _messageHandlers).ConfigureAwait(false);
+                await foreach (var work in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    try
+                    {
+                        switch (work)
+                        {
+                            case ChainSyncRollBackwardWork rollback:
+                                await _messageHandlers.RollBackwardHandler(rollback.Point, rollback.Tip).ConfigureAwait(false);
+                                break;
+                            case ChainSyncRollForwardWork forward:
+                                await _messageHandlers.RollForwardHandler(forward.Block, forward.BlockType, forward.Tip).ConfigureAwait(false);
+                                break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogError(ex, "Error executing chain sync handler.");
+                    }
+                }
             }
-            catch (Exception ex)
+            catch (OperationCanceledException)
             {
-                Console.WriteLine($"Error processing block message: {ex.Message}.");
+                _logger?.LogDebug("Chain sync handler queue cancelled.");
+            }
+            catch (ChannelClosedException)
+            {
+                // Expected during shutdown.
             }
         }
 
@@ -159,14 +241,24 @@ namespace Ogmios.Services.ChainSynchronization
 
             CancellationTokenSource sessionCts;
             BlockingCollection<PooledWebSocketMessage> sessionQueue;
+            Channel<ChainSyncBlockWork> handlerChannel;
+
             lock (_sessionLock)
             {
                 sessionCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 sessionQueue = new BlockingCollection<PooledWebSocketMessage>(boundedCapacity: 1000);
+                handlerChannel = Channel.CreateBounded<ChainSyncBlockWork>(new BoundedChannelOptions(HandlerQueueCapacity)
+                {
+                    FullMode = BoundedChannelFullMode.Wait,
+                    SingleReader = true,
+                    SingleWriter = true
+                });
                 _sessionCts = sessionCts;
                 MessageQueue = sessionQueue;
                 _sessionContexts = interactionContexts.ToList();
+                _handlerQueueWriter = handlerChannel.Writer;
             }
+
             var sessionToken = sessionCts.Token;
 
             foreach (var context in interactionContexts)
@@ -176,7 +268,8 @@ namespace Ogmios.Services.ChainSynchronization
 
             var tasks = new List<Task>
             {
-                Task.Run(() => ProcessMessagesAsync(sessionQueue, maxBlocksPerSecond, sessionToken), CancellationToken.None),
+                Task.Run(() => ProcessHandlerQueueAsync(handlerChannel.Reader, sessionToken), CancellationToken.None),
+                Task.Run(() => ProcessMessagesAsync(sessionQueue, handlerChannel.Writer, maxBlocksPerSecond, sessionToken), CancellationToken.None),
             };
 
             foreach (var context in interactionContexts)
@@ -205,21 +298,26 @@ namespace Ogmios.Services.ChainSynchronization
             CancellationTokenSource? cts;
             List<Task> tasks;
             List<Domain.InteractionContext> contexts;
+            ChannelWriter<ChainSyncBlockWork>? handlerWriter;
 
             lock (_sessionLock)
             {
                 cts = _sessionCts;
                 tasks = _sessionTasks;
                 contexts = _sessionContexts;
+                handlerWriter = _handlerQueueWriter;
                 _sessionCts = null;
                 _sessionTasks = new List<Task>();
                 _sessionContexts = new List<Domain.InteractionContext>();
+                _handlerQueueWriter = null;
             }
 
             if (cts is null && tasks.Count == 0) return;
 
             try { cts?.Cancel(); }
             catch (ObjectDisposedException) { }
+
+            handlerWriter?.TryComplete();
 
             foreach (var context in contexts)
             {
@@ -236,16 +334,16 @@ namespace Ogmios.Services.ChainSynchronization
             cts?.Dispose();
         }
 
-        private async Task RequestNextBlockAsync(Domain.InteractionContext interactionContext)
+        private Task RequestNextBlockAsync(Domain.InteractionContext interactionContext)
         {
             try
             {
-                var requestId = Guid.NewGuid();
-                await _blockService.GetNextBlockAsync(interactionContext, new MirrorOptions { Id = requestId.ToString() }).ConfigureAwait(false);
+                return _blockService.GetNextBlockAsync(interactionContext);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error requesting next block: {ex.Message}.");
+                _logger?.LogError(ex, "Error requesting next block.");
+                return Task.CompletedTask;
             }
         }
 
@@ -262,9 +360,7 @@ namespace Ogmios.Services.ChainSynchronization
             ArgumentNullException.ThrowIfNull(context);
 
             var intersection = await _intersectionService.FindIntersectionAsync(context, startingPoint).ConfigureAwait(false);
-            var tip = intersection.Result.Tip.AsTip;
-
-            return tip;
+            return intersection.Result.Tip.AsTip;
         }
     }
 }

--- a/src/Ogmios.Services/ChainSynchronization/ChainSynchronizationClientService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/ChainSynchronizationClientService.cs
@@ -107,15 +107,6 @@ namespace Ogmios.Services.ChainSynchronization
             {
                 foreach (var message in messageQueue.GetConsumingEnumerable(cancellationToken))
                 {
-                    try
-                    {
-                        await ProcessBlockMessageAsync(message.Memory).ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        message.Return();
-                    }
-
                     if (minIntervalBetweenRequests > TimeSpan.Zero)
                     {
                         var elapsed = requestStopwatch.Elapsed;
@@ -125,8 +116,19 @@ namespace Ogmios.Services.ChainSynchronization
                         }
                     }
 
+                    // Replenish the pipeline before handler work so in-flight requests stay high
+                    // even when RollForwardHandler/RollBackwardHandler is slow.
                     await RequestNextBlockAsync(message.Context).ConfigureAwait(false);
                     requestStopwatch.Restart();
+
+                    try
+                    {
+                        await ProcessBlockMessageAsync(message.Memory).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        message.Return();
+                    }
                 }
             }
             catch (OperationCanceledException)

--- a/src/Ogmios.Services/ChainSynchronization/IBlockService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/IBlockService.cs
@@ -9,4 +9,6 @@ public interface IBlockService
     Task HandleNextBlockAsync(string response, IChainSynchronizationMessageHandlers messageHandlers);
 
     Task HandleNextBlockAsync(ReadOnlyMemory<byte> utf8Response, IChainSynchronizationMessageHandlers messageHandlers);
+
+    ValueTask EnqueueBlockHandlersAsync(ReadOnlyMemory<byte> utf8Response, System.Threading.Channels.ChannelWriter<ChainSyncBlockWork> writer, CancellationToken cancellationToken = default);
 }

--- a/src/Ogmios.Services/ChainSynchronization/IWebSocketService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/IWebSocketService.cs
@@ -5,8 +5,18 @@ namespace Ogmios.Services.ChainSynchronization;
 public interface IWebSocketService
 {
     Task<IClientWebSocket> ConnectAsync(Uri addressWebSocket, ConnectionConfig connectionConfig, CancellationToken cancellationToken = default);
+
     Task SendMessageAsync(string message, IClientWebSocket clientWebSocket, CancellationToken cancellationToken = default);
+
+    Task SendMessageAsync(ReadOnlyMemory<byte> message, IClientWebSocket clientWebSocket, CancellationToken cancellationToken = default);
+
     Task<string> ReceiveMessageAsync(IClientWebSocket clientWebSocket, CancellationToken cancellationToken = default);
-    Task<string> SendAndWaitForResponseAsync(string message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = 5000, CancellationToken cancellationToken = default);
+
+    Task<byte[]> ReceiveMessageBytesAsync(IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default);
+
+    Task<string> SendAndWaitForResponseAsync(string message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default);
+
+    Task<byte[]> SendAndWaitForResponseBytesAsync(string message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default);
+
     Task CloseAsync(IClientWebSocket clientWebSocket);
 }

--- a/src/Ogmios.Services/ChainSynchronization/IWebSocketService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/IWebSocketService.cs
@@ -18,5 +18,7 @@ public interface IWebSocketService
 
     Task<byte[]> SendAndWaitForResponseBytesAsync(string message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default);
 
+    Task<byte[]> SendAndWaitForResponseBytesAsync(ReadOnlyMemory<byte> message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default);
+
     Task CloseAsync(IClientWebSocket clientWebSocket);
 }

--- a/src/Ogmios.Services/ChainSynchronization/PooledWebSocketMessage.cs
+++ b/src/Ogmios.Services/ChainSynchronization/PooledWebSocketMessage.cs
@@ -1,0 +1,23 @@
+using Ogmios.Domain;
+
+namespace Ogmios.Services.ChainSynchronization;
+
+/// <summary>
+/// A WebSocket text frame backed by an <see cref="System.Buffers.ArrayPool{T}"/> rented buffer.
+/// Return the buffer via <see cref="Return"/> after processing.
+/// </summary>
+public readonly struct PooledWebSocketMessage(byte[] buffer, int length, Domain.InteractionContext context)
+{
+    public byte[] Buffer { get; } = buffer;
+
+    public int Length { get; } = length;
+
+    public Domain.InteractionContext Context { get; } = context;
+
+    public ReadOnlyMemory<byte> Memory => new(Buffer, 0, Length);
+
+    public void Return()
+    {
+        System.Buffers.ArrayPool<byte>.Shared.Return(Buffer);
+    }
+}

--- a/src/Ogmios.Services/ChainSynchronization/WebSocketService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/WebSocketService.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Net.WebSockets;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -74,28 +75,57 @@ public class WebSocketService : IWebSocketService
 
         try
         {
-            using var memoryStream = new MemoryStream();
-            var buffer = new byte[BufferSize];
+            byte[] rented = ArrayPool<byte>.Shared.Rent(BufferSize);
+            var length = 0;
 
-            while (true)
+            try
             {
-                var result = await clientWebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), receiveToken);
+                var scratch = ArrayPool<byte>.Shared.Rent(BufferSize);
 
-                if (result.MessageType == WebSocketMessageType.Close)
+                try
                 {
-                    await clientWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
-                    throw new WebSocketException("Connection closed by the remote host.");
+                    while (true)
+                    {
+                        if (length == rented.Length)
+                        {
+                            var larger = ArrayPool<byte>.Shared.Rent(rented.Length * 2);
+                            Buffer.BlockCopy(rented, 0, larger, 0, length);
+                            ArrayPool<byte>.Shared.Return(rented);
+                            rented = larger;
+                        }
+
+                        var available = rented.Length - length;
+                        var toCopy = Math.Min(available, scratch.Length);
+                        var result = await clientWebSocket.ReceiveAsync(new ArraySegment<byte>(scratch, 0, toCopy), receiveToken).ConfigureAwait(false);
+
+                        if (result.MessageType == WebSocketMessageType.Close)
+                        {
+                            await clientWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None).ConfigureAwait(false);
+                            throw new WebSocketException("Connection closed by the remote host.");
+                        }
+
+                        Buffer.BlockCopy(scratch, 0, rented, length, result.Count);
+                        length += result.Count;
+
+                        if (result.EndOfMessage)
+                        {
+                            break;
+                        }
+                    }
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(scratch);
                 }
 
-                memoryStream.Write(buffer, 0, result.Count);
-
-                if (result.EndOfMessage)
-                {
-                    break;
-                }
+                var exact = new byte[length];
+                Buffer.BlockCopy(rented, 0, exact, 0, length);
+                return exact;
             }
-
-            return memoryStream.ToArray();
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
         }
         finally
         {
@@ -109,17 +139,35 @@ public class WebSocketService : IWebSocketService
         return Encoding.UTF8.GetString(bytes);
     }
 
-    public async Task<byte[]> SendAndWaitForResponseBytesAsync(string message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default)
+    public Task<byte[]> SendAndWaitForResponseBytesAsync(ReadOnlyMemory<byte> message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default)
     {
         try
         {
-            await SendMessageAsync(message, clientWebSocket, cancellationToken);
-            return await ReceiveMessageBytesAsync(clientWebSocket, timeoutMilliseconds, cancellationToken);
+            return SendAndWaitForResponseBytesCoreAsync(message, clientWebSocket, timeoutMilliseconds, cancellationToken);
         }
         catch (WebSocketException)
         {
             throw;
         }
+    }
+
+    public async Task<byte[]> SendAndWaitForResponseBytesAsync(string message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await SendMessageAsync(message, clientWebSocket, cancellationToken).ConfigureAwait(false);
+            return await ReceiveMessageBytesAsync(clientWebSocket, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
+        }
+        catch (WebSocketException)
+        {
+            throw;
+        }
+    }
+
+    private async Task<byte[]> SendAndWaitForResponseBytesCoreAsync(ReadOnlyMemory<byte> message, IClientWebSocket clientWebSocket, int timeoutMilliseconds, CancellationToken cancellationToken)
+    {
+        await SendMessageAsync(message, clientWebSocket, cancellationToken).ConfigureAwait(false);
+        return await ReceiveMessageBytesAsync(clientWebSocket, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
     }
 
     public async Task CloseAsync(IClientWebSocket clientWebSocket, CancellationToken cancellationToken)

--- a/src/Ogmios.Services/ChainSynchronization/WebSocketService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/WebSocketService.cs
@@ -1,4 +1,5 @@
 using System.Net.WebSockets;
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Ogmios.Domain;
@@ -24,7 +25,6 @@ public class WebSocketService : IWebSocketService
         var hostname = addressWebSocket.Host;
         var socket = ClientWebSocketWrapper.Create(hostname, connectionConfig.SslValidation);
 
-        // Log if SSL bypass is being used
         if (ClientWebSocketWrapper.HostnameRequiresSslBypass(hostname) &&
             connectionConfig.SslValidation != SslCertificateValidation.Strict)
         {
@@ -36,57 +36,85 @@ public class WebSocketService : IWebSocketService
         socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(connectionConfig.KeepAliveInterval);
         socket.Options.SetBuffer(connectionConfig.MaxPayload, connectionConfig.MaxPayload);
 
-        try
-        {
-            await socket.ConnectAsync(addressWebSocket, cancellationToken);
-        }
-        catch (Exception)
-        {
-            throw;
-        }
+        await socket.ConnectAsync(addressWebSocket, cancellationToken);
 
         return socket;
     }
 
-    public async Task SendMessageAsync(string message, IClientWebSocket clientWebSocket, CancellationToken cancellationToken = default)
+    public Task SendMessageAsync(string message, IClientWebSocket clientWebSocket, CancellationToken cancellationToken = default)
     {
         var buffer = Encoding.UTF8.GetBytes(message);
-        var segment = new ArraySegment<byte>(buffer);
-        await clientWebSocket.SendAsync(segment, WebSocketMessageType.Text, true, cancellationToken);
+        return SendMessageAsync(buffer, clientWebSocket, cancellationToken);
+    }
+
+    public Task SendMessageAsync(ReadOnlyMemory<byte> message, IClientWebSocket clientWebSocket, CancellationToken cancellationToken = default)
+    {
+        ArraySegment<byte> segment;
+        if (MemoryMarshal.TryGetArray(message, out var arraySegment))
+        {
+            segment = new ArraySegment<byte>(arraySegment.Array!, arraySegment.Offset, arraySegment.Count);
+        }
+        else
+        {
+            segment = new ArraySegment<byte>(message.ToArray());
+        }
+
+        return clientWebSocket.SendAsync(segment, WebSocketMessageType.Text, true, cancellationToken);
     }
 
     public async Task<string> ReceiveMessageAsync(IClientWebSocket clientWebSocket, CancellationToken cancellationToken = default)
     {
-        using var memoryStream = new MemoryStream();
-        var buffer = new byte[BufferSize];
-
-        while (true)
-        {
-            var result = await clientWebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), cancellationToken);
-
-            if (result.MessageType == WebSocketMessageType.Close)
-            {
-                await clientWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", cancellationToken);
-                throw new WebSocketException("Connection closed by the remote host.");
-            }
-
-            memoryStream.Write(buffer, 0, result.Count);
-
-            if (result.EndOfMessage)
-            {
-                break;
-            }
-        }
-
-        return Encoding.UTF8.GetString(memoryStream.ToArray());
+        var bytes = await ReceiveMessageBytesAsync(clientWebSocket, WebSocketTimeouts.Default, cancellationToken);
+        return Encoding.UTF8.GetString(bytes);
     }
 
-    public async Task<string> SendAndWaitForResponseAsync(string message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = 5000, CancellationToken cancellationToken = default)
+    public async Task<byte[]> ReceiveMessageBytesAsync(IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default)
+    {
+        var timeoutTokenSource = CreateTimeoutTokenSource(timeoutMilliseconds, cancellationToken, out var receiveToken);
+
+        try
+        {
+            using var memoryStream = new MemoryStream();
+            var buffer = new byte[BufferSize];
+
+            while (true)
+            {
+                var result = await clientWebSocket.ReceiveAsync(new ArraySegment<byte>(buffer), receiveToken);
+
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    await clientWebSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+                    throw new WebSocketException("Connection closed by the remote host.");
+                }
+
+                memoryStream.Write(buffer, 0, result.Count);
+
+                if (result.EndOfMessage)
+                {
+                    break;
+                }
+            }
+
+            return memoryStream.ToArray();
+        }
+        finally
+        {
+            timeoutTokenSource?.Dispose();
+        }
+    }
+
+    public async Task<string> SendAndWaitForResponseAsync(string message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default)
+    {
+        var bytes = await SendAndWaitForResponseBytesAsync(message, clientWebSocket, timeoutMilliseconds, cancellationToken);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    public async Task<byte[]> SendAndWaitForResponseBytesAsync(string message, IClientWebSocket clientWebSocket, int timeoutMilliseconds = WebSocketTimeouts.Default, CancellationToken cancellationToken = default)
     {
         try
         {
             await SendMessageAsync(message, clientWebSocket, cancellationToken);
-            return await ReceiveMessageAsync(clientWebSocket, cancellationToken);
+            return await ReceiveMessageBytesAsync(clientWebSocket, timeoutMilliseconds, cancellationToken);
         }
         catch (WebSocketException)
         {
@@ -105,5 +133,24 @@ public class WebSocketService : IWebSocketService
     public Task CloseAsync(IClientWebSocket clientWebSocket)
     {
         throw new NotImplementedException();
+    }
+
+    private static CancellationTokenSource? CreateTimeoutTokenSource(
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken,
+        out CancellationToken effectiveToken)
+    {
+        var resolvedTimeout = WebSocketTimeouts.ResolveTimeoutMilliseconds(timeoutMilliseconds);
+
+        if (resolvedTimeout == WebSocketTimeouts.Infinite)
+        {
+            effectiveToken = cancellationToken;
+            return null;
+        }
+
+        var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        linked.CancelAfter(TimeSpan.FromMilliseconds(resolvedTimeout));
+        effectiveToken = linked.Token;
+        return linked;
     }
 }

--- a/src/Ogmios.Services/ChainSynchronization/WebSocketTimeouts.cs
+++ b/src/Ogmios.Services/ChainSynchronization/WebSocketTimeouts.cs
@@ -1,0 +1,37 @@
+namespace Ogmios.Services.ChainSynchronization;
+
+/// <summary>
+/// Timeout values for WebSocket request/response operations.
+/// </summary>
+public static class WebSocketTimeouts
+{
+    /// <summary>
+    /// Do not apply a timeout; the operation may block indefinitely (e.g. acquireMempool).
+    /// </summary>
+    public const int Infinite = -1;
+
+    /// <summary>
+    /// Default timeout when callers pass <c>0</c> (use default) for standard RPC operations.
+    /// </summary>
+    public const int Default = 5000;
+
+    /// <summary>
+    /// acquireMempool blocks until the mempool snapshot changes; no client-side timeout.
+    /// </summary>
+    public const int MempoolAcquire = Infinite;
+
+    /// <summary>
+    /// Standard timeout for mempool cursor and query operations.
+    /// </summary>
+    public const int MempoolQuery = Default;
+
+    public static int ResolveTimeoutMilliseconds(int timeoutMilliseconds)
+    {
+        if (timeoutMilliseconds == Infinite)
+        {
+            return Infinite;
+        }
+
+        return timeoutMilliseconds <= 0 ? Default : timeoutMilliseconds;
+    }
+}

--- a/src/Ogmios.Services/ChainSynchronization/docs/README.md
+++ b/src/Ogmios.Services/ChainSynchronization/docs/README.md
@@ -2,9 +2,29 @@
 
 Chain synchronization is a stateful protocol that enables clients to efficiently synchronize with the Cardano blockchain. By maintaining a cursor to track synchronization progress, clients can follow the chain, handle reorganizations, and resume syncing after disconnections.
 
+## Performance-first integration
+
+Consumers using `AddOgmiosServices()` receive blocks through `IChainSynchronizationMessageHandlers`. Throughput is dominated by handler latency.
+
+### Keep handlers fast
+
+`RollForwardHandler` and `RollBackwardHandler` run on the chain sync consumer thread. **Return quickly** — filter in memory, enqueue to a bounded `Channel`, and process DB/network work on background workers. Slow handlers cause the bounded queue (1000 blocks) to fill and the bot to fall behind.
+
+### Pipeline stays full during slow handlers
+
+The client replenishes pipelined `nextBlock` requests **before** invoking your handler, so the default `inFlight=100` window stays saturated even when handlers do heavy work.
+
+### Rate limiting during catch-up
+
+Pass `maxBlocksPerSecond` to `ResumeAsync`. Values `<= 0` mean no limit. Positive values throttle how fast new `nextBlock` requests are sent after each processed block — useful to protect downstream systems when syncing from origin.
+
+### Dedicated WebSocket
+
+Use one `InteractionContext` per concurrent Ogmios protocol. Do not share a socket between chain sync and mempool monitoring.
+
 ## Key Operations
 
-1. **Find Intersection**: Establish a common synchronization point between the client’s local chain and the blockchain node. The client can provide potential points or start from the origin.
+1. **Find Intersection**: Establish a common synchronization point between the client's local chain and the blockchain node. The client can provide potential points or start from the origin.
 
 2. **Synchronize Blocks**:
    - **Roll Forward**: Process new blocks as they are added to the chain.
@@ -27,15 +47,16 @@ As new blocks are added to the chain:
 
 When a chain fork occurs:
 
-- The protocol reverts the client’s synchronization point to the last known common block.
+- The protocol reverts the client's synchronization point to the last known common block.
 - This guarantees alignment with the canonical chain and ensures data consistency.
 
 ## Pipelining
 
 Pipelining optimizes synchronization by allowing clients to send multiple requests simultaneously:
 
+- **Default `inFlight`**: 100 concurrent `nextBlock` requests primed at session start, replenished after each dequeued response.
 - **Advantages**: Reduced latency and improved bandwidth utilization.
-- **Dynamic Adjustment**: Clients can adjust the number of pipelined requests to balance resource usage and performance.
+- **Dynamic Adjustment**: Pass a lower `inFlight` if memory is constrained; raise it for faster catch-up on high-bandwidth links.
 
 ## Points of Interest
 
@@ -54,46 +75,50 @@ Triggered when the blockchain progresses to new blocks. Clients process the new 
 
 ### **Roll Backward Events**
 
-Triggered when the blockchain rolls back to a previous state (e.g., due to a fork). Clients revert their synchronization point accordingly.
+Triggered when the blockchain rolls back to a previous state (e.g., due to a fork). Clients revert their synchronization point accordingly. Process rollbacks on the same ordered pipeline as roll-forwards (or handle synchronously in the handler before returning).
 
 ## Customization
 
-The `ChainSynchronizationMessageHandlers` class provides customizable handlers for blockchain events:
+Register `IChainSynchronizationMessageHandlers` alongside `AddOgmiosServices()`:
 
-- **Roll Forward**: Extend to include actions such as persisting block data or triggering application-specific workflows.
-- **Roll Backward**: Implement logic to handle reorganizations, such as clearing unconfirmed transactions or realigning data.
+```csharp
+builder.Services.AddOgmiosServices();
+builder.Services.AddSingleton<IChainSynchronizationMessageHandlers, ChainSynchronizationMessageHandlers>();
 
-### Example Use Cases:
+await chainSynchronizationClientService.ResumeAsync(
+    [chainContext],
+    maxBlocksPerSecond: ogmiosConfiguration.MaxBlocksPerSecond,
+    inFlight: 100,
+    cancellationToken);
+```
 
-1. **Data Persistence**: Save block data to a database for analytics or audits.
-2. **Custom Logic**: Integrate application-specific behavior based on new or reorganized blockchain data.
-
-## Summary
-
-Chain synchronization offers a robust and efficient mechanism for keeping clients aligned with the Cardano blockchain. By leveraging features like intersection finding, rolling forward, rolling backward, and pipelining, clients can achieve reliable and performant synchronization tailored to their needs.
-
-## Example Code
-
-Below is an example implementation of the `ChainSynchronizationMessageHandlers` class:
+### Example handler (fast path)
 
 ```csharp
 public class ChainSynchronizationMessageHandlers : IChainSynchronizationMessageHandlers
 {
-    public async Task RollBackwardHandler(Generated.Ogmios.PointOrOrigin point, Generated.Ogmios.TipOrOrigin tip)
+    private readonly Channel<BlockWork> _work = Channel.CreateBounded<BlockWork>(500);
+
+    public Task RollBackwardHandler(Generated.Ogmios.PointOrOrigin point, Generated.Ogmios.TipOrOrigin tip)
     {
-        // Custom logic for rollback events
-        await Task.CompletedTask;
+        _work.Writer.TryWrite(BlockWork.Rollback(point, tip));
+        return Task.CompletedTask;
     }
 
-    public async Task RollForwardHandler(Block block, string blockType, Generated.Tip tip)
+    public Task RollForwardHandler(Block block, string blockType, Generated.Tip tip)
     {
-        // Custom logic for forward events
-        await Task.CompletedTask;
+        _work.Writer.TryWrite(BlockWork.RollForward(block, blockType, tip));
+        return Task.CompletedTask;
     }
 }
 ```
 
-## Key Points:
+## Summary
 
-- **RollBackwardHandler**: Can be extended to handle rollback events (e.g., saving rollback data or triggering actions).
-- **RollForwardHandler**: Can be extended to handle new blocks and act on the returned blockchain data (e.g., process or store block information).
+Chain synchronization offers a robust and efficient mechanism for keeping clients aligned with the Cardano blockchain. By leveraging pipelining, bounded queues, handler offload, and optional `maxBlocksPerSecond` throttling, clients can achieve reliable and performant synchronization tailored to their needs.
+
+## Key Points
+
+- **RollBackwardHandler**: Handle reorgs; keep synchronous if rollback state must be visible before the next forward.
+- **RollForwardHandler**: Must return quickly; the library already parses blocks from UTF-8 and maintains the pipelined window.
+- **Separate sockets**: Chain sync and mempool require different `InteractionContext` instances.

--- a/src/Ogmios.Services/ChainSynchronization/docs/README.md
+++ b/src/Ogmios.Services/ChainSynchronization/docs/README.md
@@ -79,7 +79,7 @@ Triggered when the blockchain rolls back to a previous state (e.g., due to a for
 
 ## Customization
 
-Register `IChainSynchronizationMessageHandlers` alongside `AddOgmiosServices()`:
+Register `IChainSynchronizationMessageHandlers` alongside `AddOgmiosServices()`. Handlers run on a dedicated ordered queue (capacity 2000) so block parsing and pipelining continue while your handler executes.
 
 ```csharp
 builder.Services.AddOgmiosServices();

--- a/src/Ogmios.Services/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Ogmios.Services/Extensions/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ namespace Ogmios.Services.Extensions
             services.AddSingleton<IChainSynchronizationClientService, ChainSynchronizationClientService>();
             services.AddSingleton<IBlockService, BlockService>();
             services.AddSingleton<IMemoryPoolMonitoringService, MemoryPoolMonitoringService>();
+            services.AddSingleton<IMemoryPoolMonitoringClientService, MemoryPoolMonitoringClientService>();
             services.AddSingleton<ITransactionSubmissionService, TransactionSubmissionService>();
             services.AddSingleton<ITransactionEvaluationService, TransactionEvaluationService>();
 

--- a/src/Ogmios.Services/MemoryPoolMonitoring/IMemoryPoolMonitoringClientService.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/IMemoryPoolMonitoringClientService.cs
@@ -1,0 +1,25 @@
+using Ogmios.Domain;
+
+namespace Ogmios.Services.MemoryPoolMonitoring;
+
+/// <summary>
+/// High-throughput mempool monitoring session: acquire snapshot, drain all transactions, repeat.
+/// Use a dedicated <see cref="InteractionContext"/> (separate WebSocket from chain sync).
+/// </summary>
+public interface IMemoryPoolMonitoringClientService
+{
+    /// <summary>
+    /// Runs until <paramref name="cancellationToken"/> is cancelled.
+    /// Drains every transaction in each snapshot before waiting for the next mempool change.
+    /// </summary>
+    Task RunAsync(
+        Domain.InteractionContext context,
+        IMemoryPoolMonitoringMessageHandlers handlers,
+        CancellationToken cancellationToken,
+        MemoryPoolMonitoringClientOptions? options = null);
+
+    /// <summary>
+    /// Releases the active mempool snapshot and closes the WebSocket.
+    /// </summary>
+    Task ShutdownAsync(Domain.InteractionContext context, CancellationToken cancellationToken);
+}

--- a/src/Ogmios.Services/MemoryPoolMonitoring/IMemoryPoolMonitoringMessageHandlers.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/IMemoryPoolMonitoringMessageHandlers.cs
@@ -1,0 +1,14 @@
+using Generated;
+
+namespace Ogmios.Services.MemoryPoolMonitoring;
+
+/// <summary>
+/// Callbacks invoked by <see cref="IMemoryPoolMonitoringClientService"/> for each mempool snapshot and transaction.
+/// Keep implementations fast; offload heavy work to background workers.
+/// </summary>
+public interface IMemoryPoolMonitoringMessageHandlers
+{
+    Task OnSnapshotAcquiredAsync(Generated.Slot slot, CancellationToken cancellationToken);
+
+    Task OnTransactionAsync(Transaction transaction, CancellationToken cancellationToken);
+}

--- a/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringClientOptions.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringClientOptions.cs
@@ -10,4 +10,14 @@ public sealed class MemoryPoolMonitoringClientOptions
     /// during this session are not dispatched again. Disable when every mempool appearance must be observed.
     /// </summary>
     public bool DeduplicateTransactions { get; set; } = true;
+
+    /// <summary>
+    /// Maximum queued transactions awaiting handler execution. Provides backpressure when handlers are slow.
+    /// </summary>
+    public int HandlerQueueCapacity { get; set; } = 2000;
+
+    /// <summary>
+    /// Maximum number of transaction ids tracked for deduplication before the set is reset.
+    /// </summary>
+    public int MaxDeduplicationEntries { get; set; } = 100_000;
 }

--- a/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringClientOptions.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringClientOptions.cs
@@ -1,0 +1,13 @@
+namespace Ogmios.Services.MemoryPoolMonitoring;
+
+/// <summary>
+/// Performance and behaviour options for <see cref="IMemoryPoolMonitoringClientService.RunAsync"/>.
+/// </summary>
+public sealed class MemoryPoolMonitoringClientOptions
+{
+    /// <summary>
+    /// When enabled, transactions already delivered to <see cref="IMemoryPoolMonitoringMessageHandlers.OnTransactionAsync"/>
+    /// during this session are not dispatched again. Disable when every mempool appearance must be observed.
+    /// </summary>
+    public bool DeduplicateTransactions { get; set; } = true;
+}

--- a/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringClientService.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringClientService.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+using Corvus.Json;
+using Generated;
+using Ogmios.Domain;
+
+namespace Ogmios.Services.MemoryPoolMonitoring;
+
+public class MemoryPoolMonitoringClientService(IMemoryPoolMonitoringService memoryPoolMonitoringService) : IMemoryPoolMonitoringClientService
+{
+    private readonly IMemoryPoolMonitoringService _memoryPoolMonitoringService =
+        memoryPoolMonitoringService ?? throw new ArgumentNullException(nameof(memoryPoolMonitoringService));
+
+    public async Task RunAsync(
+        Domain.InteractionContext context,
+        IMemoryPoolMonitoringMessageHandlers handlers,
+        CancellationToken cancellationToken,
+        MemoryPoolMonitoringClientOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(handlers);
+
+        options ??= new MemoryPoolMonitoringClientOptions();
+        var seenTransactionIds = options.DeduplicateTransactions
+            ? new ConcurrentDictionary<string, byte>(StringComparer.Ordinal)
+            : null;
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var acquired = await _memoryPoolMonitoringService.AcquireMempoolAsync(context, cancellationToken).ConfigureAwait(false);
+            await handlers.OnSnapshotAcquiredAsync(acquired.Slot, cancellationToken).ConfigureAwait(false);
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var next = await _memoryPoolMonitoringService.NextTransactionAsync(context, cancellationToken).ConfigureAwait(false);
+                if (next.AsTransaction.IsNullOrUndefined())
+                {
+                    break;
+                }
+
+                var transaction = next.AsTransaction;
+                if (seenTransactionIds is not null)
+                {
+                    var transactionId = (string)transaction.Id;
+                    if (!seenTransactionIds.TryAdd(transactionId, 0))
+                    {
+                        continue;
+                    }
+                }
+
+                await handlers.OnTransactionAsync(transaction, cancellationToken).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public async Task ShutdownAsync(Domain.InteractionContext context, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _memoryPoolMonitoringService.ReleaseMempoolAsync(context, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Best-effort release before closing the socket.
+        }
+
+        await _memoryPoolMonitoringService.ShutdownAsync(context, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringClientService.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringClientService.cs
@@ -1,14 +1,19 @@
 using System.Collections.Concurrent;
+using System.Threading.Channels;
 using Corvus.Json;
 using Generated;
+using Microsoft.Extensions.Logging;
 using Ogmios.Domain;
 
 namespace Ogmios.Services.MemoryPoolMonitoring;
 
-public class MemoryPoolMonitoringClientService(IMemoryPoolMonitoringService memoryPoolMonitoringService) : IMemoryPoolMonitoringClientService
+public class MemoryPoolMonitoringClientService(
+    IMemoryPoolMonitoringService memoryPoolMonitoringService,
+    ILogger<MemoryPoolMonitoringClientService>? logger = null) : IMemoryPoolMonitoringClientService
 {
     private readonly IMemoryPoolMonitoringService _memoryPoolMonitoringService =
         memoryPoolMonitoringService ?? throw new ArgumentNullException(nameof(memoryPoolMonitoringService));
+    private readonly ILogger<MemoryPoolMonitoringClientService>? _logger = logger;
 
     public async Task RunAsync(
         Domain.InteractionContext context,
@@ -24,31 +29,50 @@ public class MemoryPoolMonitoringClientService(IMemoryPoolMonitoringService memo
             ? new ConcurrentDictionary<string, byte>(StringComparer.Ordinal)
             : null;
 
-        while (!cancellationToken.IsCancellationRequested)
+        var transactionChannel = Channel.CreateBounded<Transaction>(new BoundedChannelOptions(options.HandlerQueueCapacity)
         {
-            var acquired = await _memoryPoolMonitoringService.AcquireMempoolAsync(context, cancellationToken).ConfigureAwait(false);
-            await handlers.OnSnapshotAcquiredAsync(acquired.Slot, cancellationToken).ConfigureAwait(false);
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = true
+        });
 
+        var handlerTask = ProcessTransactionQueueAsync(transactionChannel.Reader, handlers, cancellationToken);
+
+        try
+        {
             while (!cancellationToken.IsCancellationRequested)
             {
-                var next = await _memoryPoolMonitoringService.NextTransactionAsync(context, cancellationToken).ConfigureAwait(false);
-                if (next.AsTransaction.IsNullOrUndefined())
-                {
-                    break;
-                }
+                var acquired = await _memoryPoolMonitoringService.AcquireMempoolAsync(context, cancellationToken).ConfigureAwait(false);
+                await handlers.OnSnapshotAcquiredAsync(acquired.Slot, cancellationToken).ConfigureAwait(false);
 
-                var transaction = next.AsTransaction;
-                if (seenTransactionIds is not null)
+                while (!cancellationToken.IsCancellationRequested)
                 {
-                    var transactionId = (string)transaction.Id;
-                    if (!seenTransactionIds.TryAdd(transactionId, 0))
+                    var next = await _memoryPoolMonitoringService.NextTransactionAsync(context, cancellationToken).ConfigureAwait(false);
+                    if (next.AsTransaction.IsNullOrUndefined())
                     {
-                        continue;
+                        break;
                     }
-                }
 
-                await handlers.OnTransactionAsync(transaction, cancellationToken).ConfigureAwait(false);
+                    var transaction = next.AsTransaction;
+                    if (seenTransactionIds is not null)
+                    {
+                        TrimDeduplicationSetIfNeeded(seenTransactionIds, options.MaxDeduplicationEntries);
+
+                        var transactionId = (string)transaction.Id;
+                        if (!seenTransactionIds.TryAdd(transactionId, 0))
+                        {
+                            continue;
+                        }
+                    }
+
+                    await transactionChannel.Writer.WriteAsync(transaction, cancellationToken).ConfigureAwait(false);
+                }
             }
+        }
+        finally
+        {
+            transactionChannel.Writer.TryComplete();
+            await handlerTask.ConfigureAwait(false);
         }
     }
 
@@ -58,11 +82,50 @@ public class MemoryPoolMonitoringClientService(IMemoryPoolMonitoringService memo
         {
             await _memoryPoolMonitoringService.ReleaseMempoolAsync(context, cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            // Best-effort release before closing the socket.
+            _logger?.LogDebug(ex, "Best-effort mempool release failed during shutdown.");
         }
 
         await _memoryPoolMonitoringService.ShutdownAsync(context, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void TrimDeduplicationSetIfNeeded(ConcurrentDictionary<string, byte> seenTransactionIds, int maxEntries)
+    {
+        if (maxEntries <= 0 || seenTransactionIds.Count < maxEntries)
+        {
+            return;
+        }
+
+        seenTransactionIds.Clear();
+    }
+
+    private async Task ProcessTransactionQueueAsync(
+        ChannelReader<Transaction> reader,
+        IMemoryPoolMonitoringMessageHandlers handlers,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await foreach (var transaction in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+            {
+                try
+                {
+                    await handlers.OnTransactionAsync(transaction, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError(ex, "Error executing mempool transaction handler.");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger?.LogDebug("Mempool handler queue cancelled.");
+        }
+        catch (ChannelClosedException)
+        {
+            // Expected during shutdown.
+        }
     }
 }

--- a/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringExtensions.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringExtensions.cs
@@ -1,3 +1,4 @@
+using System.Threading.Channels;
 using Corvus.Json;
 using Generated;
 using Ogmios.Domain;
@@ -37,29 +38,67 @@ public static class MemoryPoolMonitoringExtensions
 
     /// <summary>
     /// High-throughput monitoring loop: acquire snapshot, drain all transactions, wait for next change, repeat.
-    /// Uses only acquire + nextTransaction RPCs on the hot path.
+    /// Uses only acquire + nextTransaction RPCs on the hot path and offloads callbacks to a bounded queue.
     /// </summary>
     public static async Task MonitorAsync(
         this IMemoryPoolMonitoringService service,
         Domain.InteractionContext context,
         Func<Transaction, CancellationToken, Task> onTransaction,
         CancellationToken cancellationToken,
-        Func<Generated.Slot, CancellationToken, Task>? onSnapshotAcquired = null)
+        Func<Generated.Slot, CancellationToken, Task>? onSnapshotAcquired = null,
+        int handlerQueueCapacity = 2000)
     {
         ArgumentNullException.ThrowIfNull(service);
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(onTransaction);
 
-        while (!cancellationToken.IsCancellationRequested)
+        var transactionChannel = Channel.CreateBounded<Transaction>(new BoundedChannelOptions(handlerQueueCapacity)
         {
-            var acquired = await service.AcquireMempoolAsync(context, cancellationToken).ConfigureAwait(false);
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = true
+        });
 
-            if (onSnapshotAcquired is not null)
+        var handlerTask = ProcessTransactionCallbacksAsync(transactionChannel.Reader, onTransaction, cancellationToken);
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
             {
-                await onSnapshotAcquired(acquired.Slot, cancellationToken).ConfigureAwait(false);
-            }
+                var acquired = await service.AcquireMempoolAsync(context, cancellationToken).ConfigureAwait(false);
 
-            await service.DrainSnapshotAsync(context, onTransaction, cancellationToken).ConfigureAwait(false);
+                if (onSnapshotAcquired is not null)
+                {
+                    await onSnapshotAcquired(acquired.Slot, cancellationToken).ConfigureAwait(false);
+                }
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var next = await service.NextTransactionAsync(context, cancellationToken).ConfigureAwait(false);
+                    if (next.AsTransaction.IsNullOrUndefined())
+                    {
+                        break;
+                    }
+
+                    await transactionChannel.Writer.WriteAsync(next.AsTransaction, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        finally
+        {
+            transactionChannel.Writer.TryComplete();
+            await handlerTask.ConfigureAwait(false);
+        }
+    }
+
+    private static async Task ProcessTransactionCallbacksAsync(
+        ChannelReader<Transaction> reader,
+        Func<Transaction, CancellationToken, Task> onTransaction,
+        CancellationToken cancellationToken)
+    {
+        await foreach (var transaction in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+        {
+            await onTransaction(transaction, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringExtensions.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringExtensions.cs
@@ -1,0 +1,65 @@
+using Corvus.Json;
+using Generated;
+using Ogmios.Domain;
+
+namespace Ogmios.Services.MemoryPoolMonitoring;
+
+/// <summary>
+/// Performance-oriented helpers for consumers calling <see cref="IMemoryPoolMonitoringService"/> directly.
+/// </summary>
+public static class MemoryPoolMonitoringExtensions
+{
+    /// <summary>
+    /// Drains every transaction from the currently acquired mempool snapshot.
+    /// Call after <see cref="IMemoryPoolMonitoringService.AcquireMempoolAsync"/>.
+    /// </summary>
+    public static async Task DrainSnapshotAsync(
+        this IMemoryPoolMonitoringService service,
+        Domain.InteractionContext context,
+        Func<Transaction, CancellationToken, Task> onTransaction,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(onTransaction);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var next = await service.NextTransactionAsync(context, cancellationToken).ConfigureAwait(false);
+            if (next.AsTransaction.IsNullOrUndefined())
+            {
+                break;
+            }
+
+            await onTransaction(next.AsTransaction, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// High-throughput monitoring loop: acquire snapshot, drain all transactions, wait for next change, repeat.
+    /// Uses only acquire + nextTransaction RPCs on the hot path.
+    /// </summary>
+    public static async Task MonitorAsync(
+        this IMemoryPoolMonitoringService service,
+        Domain.InteractionContext context,
+        Func<Transaction, CancellationToken, Task> onTransaction,
+        CancellationToken cancellationToken,
+        Func<Generated.Slot, CancellationToken, Task>? onSnapshotAcquired = null)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(onTransaction);
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var acquired = await service.AcquireMempoolAsync(context, cancellationToken).ConfigureAwait(false);
+
+            if (onSnapshotAcquired is not null)
+            {
+                await onSnapshotAcquired(acquired.Slot, cancellationToken).ConfigureAwait(false);
+            }
+
+            await service.DrainSnapshotAsync(context, onTransaction, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringService.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringService.cs
@@ -10,9 +10,19 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
 {
     public async Task<Generated.Ogmios.AcquireMempoolResponse.RequiredAcquiredAndSlot> AcquireMempoolAsync(Domain.InteractionContext context, CancellationToken cancellationToken, MirrorOptions? mirrorOptions = default)
     {
-        var acquireMempoolRequest = Generated.Ogmios.AcquireMempool.Create(jsonrpc: Generated.Ogmios.AcquireMempool.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.AcquireMempool.MethodEntity.EnumValues.AcquireMempool, id: mirrorOptions?.Id ?? string.Empty);
-        var message = acquireMempoolRequest.AsJsonElement.ToString();
-        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolAcquire, cancellationToken);
+        byte[] responseBytes;
+        if (mirrorOptions?.Id is { Length: > 0 })
+        {
+            var message = Generated.Ogmios.AcquireMempool.Create(
+                jsonrpc: Generated.Ogmios.AcquireMempool.JsonrpcEntity.EnumValues.Value20,
+                method: Generated.Ogmios.AcquireMempool.MethodEntity.EnumValues.AcquireMempool,
+                id: mirrorOptions.Id).AsJsonElement.ToString();
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolAcquire, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(MempoolRpcRequests.Acquire, context.Socket, WebSocketTimeouts.MempoolAcquire, cancellationToken).ConfigureAwait(false);
+        }
 
         var responseEntity = ParsedValue<Generated.Ogmios.AcquireMempoolResponse>.Parse(responseBytes).Instance;
 
@@ -26,11 +36,23 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
 
     public async Task<Generated.Ogmios.HasTransactionResponseEntity.HasTransactionResponse> HasTransactionAsync(Domain.InteractionContext context, string transactionId, CancellationToken cancellationToken, MirrorOptions? mirrorOptions = default)
     {
-        var transactionIdEntity = TransactionId.FromAny(transactionId);
-        var hasTransactionRequest = Generated.Ogmios.HasTransaction.Create(jsonrpc: Generated.Ogmios.HasTransaction.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.HasTransaction.MethodEntity.EnumValues.HasTransaction,
-                                                                           Generated.Ogmios.HasTransaction.RequiredId.Create(transactionIdEntity), id: mirrorOptions?.Id ?? string.Empty);
-        var message = hasTransactionRequest.AsJsonElement.ToString();
-        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken);
+        byte[] responseBytes;
+        if (mirrorOptions?.Id is { Length: > 0 })
+        {
+            var transactionIdEntity = TransactionId.FromAny(transactionId);
+            var message = Generated.Ogmios.HasTransaction.Create(
+                jsonrpc: Generated.Ogmios.HasTransaction.JsonrpcEntity.EnumValues.Value20,
+                method: Generated.Ogmios.HasTransaction.MethodEntity.EnumValues.HasTransaction,
+                Generated.Ogmios.HasTransaction.RequiredId.Create(transactionIdEntity),
+                id: mirrorOptions.Id).AsJsonElement.ToString();
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            var requestBytes = MempoolRpcRequests.BuildHasTransactionRequest(transactionId.AsSpan());
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(requestBytes, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken).ConfigureAwait(false);
+        }
+
         var responseEntity = ParsedValue<Generated.Ogmios.HasTransactionResponseEntity>.Parse(responseBytes).Instance;
 
         if (responseEntity.IsMustAcquireMempoolFirst)
@@ -44,10 +66,20 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
 
     public async Task<Generated.Ogmios.NextTransactionResponseEntity.NextTransactionResponse.RequiredTransaction.TransactionEntity> NextTransactionAsync(Domain.InteractionContext context, CancellationToken cancellationToken, MirrorOptions? mirrorOptions = default)
     {
-        var nextTransactionRequest = Generated.Ogmios.NextTransaction.Create(jsonrpc: Generated.Ogmios.NextTransaction.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.NextTransaction.MethodEntity.EnumValues.NextTransaction,
-                                                                             id: mirrorOptions?.Id ?? string.Empty, paramsValue: Generated.Ogmios.NextTransaction.ParamsEntity.Create(Generated.Ogmios.NextTransaction.ParamsEntity.FieldsEntity.EnumValues.All));
-        var message = nextTransactionRequest.AsJsonElement.ToString();
-        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken);
+        byte[] responseBytes;
+        if (mirrorOptions?.Id is { Length: > 0 })
+        {
+            var message = Generated.Ogmios.NextTransaction.Create(
+                jsonrpc: Generated.Ogmios.NextTransaction.JsonrpcEntity.EnumValues.Value20,
+                method: Generated.Ogmios.NextTransaction.MethodEntity.EnumValues.NextTransaction,
+                id: mirrorOptions.Id,
+                paramsValue: Generated.Ogmios.NextTransaction.ParamsEntity.Create(Generated.Ogmios.NextTransaction.ParamsEntity.FieldsEntity.EnumValues.All)).AsJsonElement.ToString();
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(MempoolRpcRequests.NextTransactionAllFields, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken).ConfigureAwait(false);
+        }
 
         var responseEntity = ParsedValue<Generated.Ogmios.NextTransactionResponseEntity>.Parse(responseBytes).Instance;
 
@@ -62,9 +94,19 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
 
     public async Task<Generated.Ogmios.MempoolSizeAndCapacity> SizeOfMempoolAsync(Domain.InteractionContext context, CancellationToken cancellationToken, MirrorOptions? mirrorOptions = default)
     {
-        var sizeOfMempoolRequest = Generated.Ogmios.SizeOfMempool.Create(jsonrpc: Generated.Ogmios.SizeOfMempool.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.SizeOfMempool.MethodEntity.EnumValues.SizeOfMempool, id: mirrorOptions?.Id ?? string.Empty);
-        var message = sizeOfMempoolRequest.AsJsonElement.ToString();
-        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken);
+        byte[] responseBytes;
+        if (mirrorOptions?.Id is { Length: > 0 })
+        {
+            var message = Generated.Ogmios.SizeOfMempool.Create(
+                jsonrpc: Generated.Ogmios.SizeOfMempool.JsonrpcEntity.EnumValues.Value20,
+                method: Generated.Ogmios.SizeOfMempool.MethodEntity.EnumValues.SizeOfMempool,
+                id: mirrorOptions.Id).AsJsonElement.ToString();
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(MempoolRpcRequests.SizeOfMempool, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken).ConfigureAwait(false);
+        }
 
         var responseEntity = ParsedValue<Generated.Ogmios.SizeOfMempoolResponseEntity>.Parse(responseBytes).Instance;
 
@@ -79,9 +121,19 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
 
     public async Task<Generated.Ogmios.ReleaseMempoolResponseEntity.ReleaseMempoolResponse.RequiredReleased> ReleaseMempoolAsync(Domain.InteractionContext context, CancellationToken cancellationToken, MirrorOptions? mirrorOptions = default)
     {
-        var releaseMempoolRequest = Generated.Ogmios.ReleaseMempool.Create(jsonrpc: Generated.Ogmios.ReleaseMempool.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.ReleaseMempool.MethodEntity.EnumValues.ReleaseMempool, id: mirrorOptions?.Id ?? string.Empty);
-        var message = releaseMempoolRequest.AsJsonElement.ToString();
-        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken);
+        byte[] responseBytes;
+        if (mirrorOptions?.Id is { Length: > 0 })
+        {
+            var message = Generated.Ogmios.ReleaseMempool.Create(
+                jsonrpc: Generated.Ogmios.ReleaseMempool.JsonrpcEntity.EnumValues.Value20,
+                method: Generated.Ogmios.ReleaseMempool.MethodEntity.EnumValues.ReleaseMempool,
+                id: mirrorOptions.Id).AsJsonElement.ToString();
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(MempoolRpcRequests.ReleaseMempool, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken).ConfigureAwait(false);
+        }
 
         var responseEntity = ParsedValue<Generated.Ogmios.ReleaseMempoolResponseEntity>.Parse(responseBytes).Instance;
 

--- a/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringService.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/MemoryPoolMonitoringService.cs
@@ -12,9 +12,9 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
     {
         var acquireMempoolRequest = Generated.Ogmios.AcquireMempool.Create(jsonrpc: Generated.Ogmios.AcquireMempool.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.AcquireMempool.MethodEntity.EnumValues.AcquireMempool, id: mirrorOptions?.Id ?? string.Empty);
         var message = acquireMempoolRequest.AsJsonElement.ToString();
-        var responseMessage = await webSocketService.SendAndWaitForResponseAsync(message, context.Socket, timeoutMilliseconds: default, cancellationToken);
+        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolAcquire, cancellationToken);
 
-        var responseEntity = ParsedValue<Generated.Ogmios.AcquireMempoolResponse>.Parse(responseMessage).Instance;
+        var responseEntity = ParsedValue<Generated.Ogmios.AcquireMempoolResponse>.Parse(responseBytes).Instance;
 
         if (responseEntity.Result.Acquired != Generated.Ogmios.AcquireMempoolResponse.RequiredAcquiredAndSlot.AcquiredEntity.EnumValues.Mempool)
         {
@@ -30,8 +30,8 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
         var hasTransactionRequest = Generated.Ogmios.HasTransaction.Create(jsonrpc: Generated.Ogmios.HasTransaction.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.HasTransaction.MethodEntity.EnumValues.HasTransaction,
                                                                            Generated.Ogmios.HasTransaction.RequiredId.Create(transactionIdEntity), id: mirrorOptions?.Id ?? string.Empty);
         var message = hasTransactionRequest.AsJsonElement.ToString();
-        var responseMessage = await webSocketService.SendAndWaitForResponseAsync(message, context.Socket, timeoutMilliseconds: default, cancellationToken) ?? throw new InvalidOperationException("The response message is null.");
-        var responseEntity = ParsedValue<Generated.Ogmios.HasTransactionResponseEntity>.Parse(responseMessage).Instance;
+        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken);
+        var responseEntity = ParsedValue<Generated.Ogmios.HasTransactionResponseEntity>.Parse(responseBytes).Instance;
 
         if (responseEntity.IsMustAcquireMempoolFirst)
         {
@@ -47,9 +47,9 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
         var nextTransactionRequest = Generated.Ogmios.NextTransaction.Create(jsonrpc: Generated.Ogmios.NextTransaction.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.NextTransaction.MethodEntity.EnumValues.NextTransaction,
                                                                              id: mirrorOptions?.Id ?? string.Empty, paramsValue: Generated.Ogmios.NextTransaction.ParamsEntity.Create(Generated.Ogmios.NextTransaction.ParamsEntity.FieldsEntity.EnumValues.All));
         var message = nextTransactionRequest.AsJsonElement.ToString();
-        var responseMessage = await webSocketService.SendAndWaitForResponseAsync(message, context.Socket, timeoutMilliseconds: default, cancellationToken);
+        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken);
 
-        var responseEntity = ParsedValue<Generated.Ogmios.NextTransactionResponseEntity>.Parse(responseMessage).Instance;
+        var responseEntity = ParsedValue<Generated.Ogmios.NextTransactionResponseEntity>.Parse(responseBytes).Instance;
 
         if (responseEntity.IsMustAcquireMempoolFirst)
         {
@@ -64,9 +64,9 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
     {
         var sizeOfMempoolRequest = Generated.Ogmios.SizeOfMempool.Create(jsonrpc: Generated.Ogmios.SizeOfMempool.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.SizeOfMempool.MethodEntity.EnumValues.SizeOfMempool, id: mirrorOptions?.Id ?? string.Empty);
         var message = sizeOfMempoolRequest.AsJsonElement.ToString();
-        var responseMessage = await webSocketService.SendAndWaitForResponseAsync(message, context.Socket, timeoutMilliseconds: default, cancellationToken);
+        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken);
 
-        var responseEntity = ParsedValue<Generated.Ogmios.SizeOfMempoolResponseEntity>.Parse(responseMessage).Instance;
+        var responseEntity = ParsedValue<Generated.Ogmios.SizeOfMempoolResponseEntity>.Parse(responseBytes).Instance;
 
         if (responseEntity.IsMustAcquireMempoolFirst)
         {
@@ -81,9 +81,9 @@ public class MemoryPoolMonitoringService(IWebSocketService webSocketService) : I
     {
         var releaseMempoolRequest = Generated.Ogmios.ReleaseMempool.Create(jsonrpc: Generated.Ogmios.ReleaseMempool.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.ReleaseMempool.MethodEntity.EnumValues.ReleaseMempool, id: mirrorOptions?.Id ?? string.Empty);
         var message = releaseMempoolRequest.AsJsonElement.ToString();
-        var responseMessage = await webSocketService.SendAndWaitForResponseAsync(message, context.Socket, timeoutMilliseconds: default, cancellationToken);
+        var responseBytes = await webSocketService.SendAndWaitForResponseBytesAsync(message, context.Socket, WebSocketTimeouts.MempoolQuery, cancellationToken);
 
-        var responseEntity = ParsedValue<Generated.Ogmios.ReleaseMempoolResponseEntity>.Parse(responseMessage).Instance;
+        var responseEntity = ParsedValue<Generated.Ogmios.ReleaseMempoolResponseEntity>.Parse(responseBytes).Instance;
 
         if (responseEntity.IsMustAcquireMempoolFirst)
         {

--- a/src/Ogmios.Services/MemoryPoolMonitoring/MempoolRpcRequests.cs
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/MempoolRpcRequests.cs
@@ -1,0 +1,46 @@
+using System.Buffers;
+using System.Text;
+
+namespace Ogmios.Services.MemoryPoolMonitoring;
+
+/// <summary>
+/// Pre-serialized UTF-8 JSON-RPC request bodies for mempool hot-path calls.
+/// </summary>
+internal static class MempoolRpcRequests
+{
+    internal static ReadOnlyMemory<byte> Acquire { get; } = Encoding.UTF8.GetBytes("{\"jsonrpc\":\"2.0\",\"method\":\"acquireMempool\"}");
+
+    internal static ReadOnlyMemory<byte> NextTransactionAllFields { get; } =
+        Encoding.UTF8.GetBytes("{\"jsonrpc\":\"2.0\",\"method\":\"nextTransaction\",\"params\":{\"fields\":\"all\"}}");
+
+    internal static ReadOnlyMemory<byte> SizeOfMempool { get; } = Encoding.UTF8.GetBytes("{\"jsonrpc\":\"2.0\",\"method\":\"sizeOfMempool\"}");
+
+    internal static ReadOnlyMemory<byte> ReleaseMempool { get; } = Encoding.UTF8.GetBytes("{\"jsonrpc\":\"2.0\",\"method\":\"releaseMempool\"}");
+
+    private static ReadOnlyMemory<byte> HasTransactionPrefix { get; } =
+        Encoding.UTF8.GetBytes("{\"jsonrpc\":\"2.0\",\"method\":\"hasTransaction\",\"params\":{\"id\":\"");
+
+    private static ReadOnlyMemory<byte> HasTransactionSuffix { get; } = Encoding.UTF8.GetBytes("\"}}");
+
+    internal static byte[] BuildHasTransactionRequest(ReadOnlySpan<char> transactionId)
+    {
+        var idByteCount = Encoding.UTF8.GetByteCount(transactionId);
+        var length = HasTransactionPrefix.Length + idByteCount + HasTransactionSuffix.Length;
+        var buffer = ArrayPool<byte>.Shared.Rent(length);
+
+        try
+        {
+            HasTransactionPrefix.Span.CopyTo(buffer);
+            Encoding.UTF8.GetBytes(transactionId, buffer.AsSpan(HasTransactionPrefix.Length));
+            HasTransactionSuffix.Span.CopyTo(buffer.AsSpan(HasTransactionPrefix.Length + idByteCount));
+
+            var exact = new byte[length];
+            buffer.AsSpan(0, length).CopyTo(exact);
+            return exact;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/src/Ogmios.Services/MemoryPoolMonitoring/docs/README.md
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/docs/README.md
@@ -28,6 +28,8 @@ Implement `IMemoryPoolMonitoringMessageHandlers`:
 
 Set `DeduplicateTransactions = false` when every mempool appearance of the same transaction id must be observed.
 
+`HandlerQueueCapacity` controls backpressure when `OnTransactionAsync` is slower than snapshot draining. `MaxDeduplicationEntries` prevents unbounded deduplication memory in long sessions.
+
 ### 2. Direct RPC with extension helpers
 
 If you call `IMemoryPoolMonitoringService` directly, use `MemoryPoolMonitoringExtensions`:

--- a/src/Ogmios.Services/MemoryPoolMonitoring/docs/README.md
+++ b/src/Ogmios.Services/MemoryPoolMonitoring/docs/README.md
@@ -2,16 +2,60 @@
 
 Memory pool monitoring enables real-time interaction and analysis of the Cardano node's mempool. It allows clients to acquire snapshots, query transactions, and manage system resources efficiently.
 
+## Performance-first integration
+
+For bots and low-latency consumers registered via `AddOgmiosServices()`, prefer one of these patterns:
+
+### 1. Orchestrated monitoring (recommended)
+
+`IMemoryPoolMonitoringClientService` runs the correct high-throughput loop for you: **acquire → drain all transactions → wait for next snapshot → repeat**. It uses only `acquireMempool` and `nextTransaction` on the hot path (no extra size/has RPCs).
+
+```csharp
+builder.Services.AddOgmiosServices();
+
+// Pass your handler when starting the session (no extra DI registration required).
+await memoryPoolMonitoringClientService.RunAsync(
+    mempoolContext,
+    myHandlers,
+    cancellationToken,
+    new MemoryPoolMonitoringClientOptions { DeduplicateTransactions = true });
+```
+
+Implement `IMemoryPoolMonitoringMessageHandlers`:
+
+- `OnSnapshotAcquiredAsync` — snapshot changed; keep this fast (metrics/logging only).
+- `OnTransactionAsync` — each new transaction; filter in memory and enqueue heavy work to background workers.
+
+Set `DeduplicateTransactions = false` when every mempool appearance of the same transaction id must be observed.
+
+### 2. Direct RPC with extension helpers
+
+If you call `IMemoryPoolMonitoringService` directly, use `MemoryPoolMonitoringExtensions`:
+
+```csharp
+// Drain the current snapshot after acquire
+await memoryPoolMonitoringService.DrainSnapshotAsync(context, OnTransactionAsync, cancellationToken);
+
+// Full monitoring loop (acquire → drain → repeat)
+await memoryPoolMonitoringService.MonitorAsync(context, OnTransactionAsync, cancellationToken);
+```
+
+**Always drain until `nextTransaction` returns null** before calling `acquireMempool` again. Re-acquiring early skips transactions still on the snapshot cursor.
+
+### 3. Dedicated WebSocket
+
+Use a **separate `InteractionContext`** for mempool monitoring. Do not share a WebSocket with chain sync — the chain sync listener and blocking mempool RPCs will steal each other's frames.
+
 ## Key Operations
 
-1. **Acquire Mempool**: Use `AcquireMempoolAsync` to acquire a snapshot of the mempool. This ensures consistent data and prevents duplicate transaction processing.
+1. **Acquire Mempool**: Use `AcquireMempoolAsync` to acquire a snapshot of the mempool. Blocks until the snapshot changes relative to the prior acquire.
 
 2. **List Transactions**:
 
-   - Retrieve transactions sequentially using `NextTransactionAsync`.
-   - Check if a specific transaction exists using `HasTransactionAsync`.
+   - Retrieve transactions sequentially using `NextTransactionAsync` until the cursor is exhausted (null transaction).
+   - Check if a specific transaction exists using `HasTransactionAsync` (optional; not needed when draining).
 
-3. **Query Mempool Details**: Fetch mempool size, number of transactions, and capacity using `SizeOfMempoolAsync`.
+3. **Query Mempool Details**: Fetch mempool size and capacity using `SizeOfMempoolAsync` (metrics only; omit from hot paths).
 
 4. **Release Mempool**: Use `ReleaseMempoolAsync` to release the acquired snapshot and free up resources.
 
@@ -28,28 +72,32 @@ Clients must acquire a snapshot using `AcquireMempoolAsync` before performing an
 ### **Snapshot Lifecycle**
 
 1. **Acquire**: Start by acquiring the snapshot (`AcquireMempoolAsync`).
-2. **Query**: Perform operations such as listing transactions or checking the mempool size.
-3. **Release**: Once done, release the snapshot (`ReleaseMempoolAsync`) to free resources.
+2. **Drain**: Call `NextTransactionAsync` in a loop until null.
+3. **Repeat**: Acquire again to wait for the next mempool change.
+4. **Release** (shutdown): `ReleaseMempoolAsync` then close the socket.
 
 ## Error Handling
 
 1. **Must Acquire Mempool First**: Ensure a snapshot is acquired before operations like `HasTransactionAsync` or `SizeOfMempoolAsync`.
-2. **Transaction Not Found**: Validate the transaction ID if it’s missing from the mempool.
-3. **Timeouts**: Increase the timeout or verify network connectivity if operations take too long.
+2. **Transaction Not Found**: Validate the transaction ID if it's missing from the mempool.
+3. **Timeouts**: Mempool acquire uses an infinite client timeout (blocks until the snapshot changes). Query operations use `WebSocketTimeouts.MempoolQuery` (5 seconds by default).
 
 ## Summary of Methods
 
-| Method                 | Purpose                        | Notes                                   |
-| ---------------------- | ------------------------------ | --------------------------------------- |
-| `AcquireMempoolAsync`  | Acquire a mempool snapshot.    | Required for all subsequent operations. |
-| `HasTransactionAsync`  | Check if a transaction exists. | Operates on the acquired snapshot.      |
-| `NextTransactionAsync` | Retrieve the next transaction. | Processes sequentially.                 |
-| `SizeOfMempoolAsync`   | Get mempool size and capacity. | Requires an active snapshot.            |
-| `ReleaseMempoolAsync`  | Release the acquired snapshot. | Frees resources for other clients.      |
-| `ShutdownAsync`        | Gracefully close WebSocket.    | Ensure all queries are completed first. |
+| Method | Purpose | Hot path? |
+| ------ | ------- | --------- |
+| `AcquireMempoolAsync` | Acquire a mempool snapshot | Yes |
+| `NextTransactionAsync` | Advance snapshot cursor | Yes |
+| `IMemoryPoolMonitoringClientService.RunAsync` | Acquire + drain loop with handlers | Yes (recommended) |
+| `MemoryPoolMonitoringExtensions.MonitorAsync` | Extension-based acquire + drain loop | Yes |
+| `HasTransactionAsync` | Point lookup by transaction id | No (targeted checks only) |
+| `SizeOfMempoolAsync` | Mempool size/capacity metrics | No |
+| `ReleaseMempoolAsync` | Release snapshot | Shutdown |
+| `ShutdownAsync` | Close WebSocket | Shutdown |
 
 ## Notes
 
 - **Transaction Locality**: Transactions from peers or local submissions may be visible.
 - **Transaction Observability**: Not all transactions are guaranteed to be observable due to race conditions.
 - **Transaction Status**: Presence in the mempool indicates pending status but does not guarantee inclusion in the ledger.
+- **Deduplication**: The same transaction can appear in consecutive snapshots until included or evicted; enable deduplication in `MemoryPoolMonitoringClientOptions` unless you need every appearance.

--- a/src/Ogmios.Services/Ogmios.Services.csproj
+++ b/src/Ogmios.Services/Ogmios.Services.csproj
@@ -18,10 +18,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Ogmios.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Corvus.Json.ExtendedTypes" Version="4.5.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
     <PackageReference Include="System.Linq.Async" Version="6.0.3" />
   </ItemGroup>

--- a/src/Ogmios.Services/Ogmios.Services.csproj
+++ b/src/Ogmios.Services/Ogmios.Services.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Ogmios.Services</RootNamespace>
     
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.14.0.2</Version>
+    <Version>6.14.0.3</Version>
     <Authors>Dave B</Authors>
     <PackageId>OgmiosDotnetClient.Services</PackageId>
     <Description>A set of services and extensions for integrating Ogmios functionality, including chain synchronization, memory pool monitoring, transaction submission, transaction evaluation, ledger state queries, and server health monitoring.</Description>

--- a/src/Ogmios.Tests/ChainSynchronization/ChainSynchronizationClientServiceTests.cs
+++ b/src/Ogmios.Tests/ChainSynchronization/ChainSynchronizationClientServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Net.WebSockets;
 using System.Text;
+using System.Threading.Channels;
 using Generated;
 using Moq;
 using Ogmios.Domain;
@@ -181,9 +182,9 @@ namespace Ogmios.Tests.ChainSynchronization
 
             // Assert
             _mockBlockService.Verify(
-                x => x.HandleNextBlockAsync(It.Is<ReadOnlyMemory<byte>>(b => Encoding.UTF8.GetString(b.ToArray()) == message), _mockMessageHandlers.Object),
+                x => x.EnqueueBlockHandlersAsync(It.Is<ReadOnlyMemory<byte>>(b => Encoding.UTF8.GetString(b.ToArray()) == message), It.IsAny<System.Threading.Channels.ChannelWriter<ChainSyncBlockWork>>(), It.IsAny<CancellationToken>()),
                 Times.Once,
-                "Expected HandleNextBlockAsync to be called once with the correct message and handlers."
+                "Expected EnqueueBlockHandlersAsync to be called once with the correct message."
             );
         }
 
@@ -224,12 +225,12 @@ namespace Ogmios.Tests.ChainSynchronization
                 });
 
             // Setup the message handlers to log the order of message processing
-            _mockBlockService.Setup(x => x.HandleNextBlockAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<IChainSynchronizationMessageHandlers>()))
-                .Callback<ReadOnlyMemory<byte>, IChainSynchronizationMessageHandlers>((bytes, _) =>
+            _mockBlockService.Setup(x => x.EnqueueBlockHandlersAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<ChannelWriter<ChainSyncBlockWork>>(), It.IsAny<CancellationToken>()))
+                .Callback<ReadOnlyMemory<byte>, ChannelWriter<ChainSyncBlockWork>, CancellationToken>((bytes, _, _) =>
                 {
                     messageLog.Add(Encoding.UTF8.GetString(bytes.Span));
                 })
-                .Returns(Task.CompletedTask);
+                .Returns(ValueTask.CompletedTask);
 
             // Act
             await _service.ResumeListeningAsync(interactionContext, cancellationTokenSource.Token);

--- a/src/Ogmios.Tests/ChainSynchronization/ChainSynchronizationClientServiceTests.cs
+++ b/src/Ogmios.Tests/ChainSynchronization/ChainSynchronizationClientServiceTests.cs
@@ -74,9 +74,10 @@ namespace Ogmios.Tests.ChainSynchronization
 
             // Assert
             Assert.Single(_service.MessageQueue);
-            var (queuedBytes, context) = _service.MessageQueue.First();
-            Assert.Equal(message, Encoding.UTF8.GetString(queuedBytes));
-            Assert.Equal(interactionContext, context);
+            var queuedMessage = _service.MessageQueue.First();
+            Assert.Equal(message, Encoding.UTF8.GetString(queuedMessage.Memory.Span));
+            Assert.Equal(interactionContext, queuedMessage.Context);
+            queuedMessage.Return();
 
             mockSocket.Verify(
                 x => x.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by client", It.IsAny<CancellationToken>()),

--- a/src/Ogmios.Tests/ChainSynchronization/WebSocketServiceTests.cs
+++ b/src/Ogmios.Tests/ChainSynchronization/WebSocketServiceTests.cs
@@ -1,0 +1,15 @@
+using Ogmios.Services.ChainSynchronization;
+
+namespace Ogmios.Tests.ChainSynchronization;
+
+public class WebSocketServiceTests
+{
+    [Theory]
+    [InlineData(WebSocketTimeouts.Infinite, WebSocketTimeouts.Infinite)]
+    [InlineData(0, WebSocketTimeouts.Default)]
+    [InlineData(2500, 2500)]
+    public void ResolveTimeoutMilliseconds_ReturnsExpectedValue(int input, int expected)
+    {
+        Assert.Equal(expected, WebSocketTimeouts.ResolveTimeoutMilliseconds(input));
+    }
+}

--- a/src/Ogmios.Tests/MemoryPoolMonitoring/MemoryPoolMonitoringClientServiceTests.cs
+++ b/src/Ogmios.Tests/MemoryPoolMonitoring/MemoryPoolMonitoringClientServiceTests.cs
@@ -1,0 +1,190 @@
+using System.Net.WebSockets;
+using Corvus.Json;
+using Generated;
+using Moq;
+using Ogmios.Domain;
+using Ogmios.Services.MemoryPoolMonitoring;
+
+namespace Ogmios.Tests.MemoryPoolMonitoring;
+
+public class MemoryPoolMonitoringClientServiceTests
+{
+    [Fact]
+    public async Task RunAsync_DrainsEveryTransactionBeforeNextAcquire()
+    {
+        var mempoolService = new Mock<IMemoryPoolMonitoringService>();
+        var handlers = new Mock<IMemoryPoolMonitoringMessageHandlers>();
+        var slot = Generated.Slot.ParseValue("12345");
+        var transaction = CreateSampleTransaction("tx-one");
+
+        var acquireCount = 0;
+        var nextCall = 0;
+        var cancellationTokenSource = new CancellationTokenSource();
+
+        mempoolService
+            .Setup(x => x.AcquireMempoolAsync(It.IsAny<InteractionContext>(), It.IsAny<CancellationToken>(), It.IsAny<MirrorOptions?>()))
+            .ReturnsAsync(() =>
+            {
+                acquireCount++;
+                if (acquireCount > 1)
+                {
+                    cancellationTokenSource.Cancel();
+                }
+
+                return Generated.Ogmios.AcquireMempoolResponse.RequiredAcquiredAndSlot.Create(
+                    acquired: Generated.Ogmios.AcquireMempoolResponse.RequiredAcquiredAndSlot.AcquiredEntity.EnumValues.Mempool,
+                    slot: slot);
+            });
+
+        mempoolService
+            .Setup(x => x.NextTransactionAsync(It.IsAny<InteractionContext>(), It.IsAny<CancellationToken>(), It.IsAny<MirrorOptions?>()))
+            .ReturnsAsync(() =>
+            {
+                nextCall++;
+                return nextCall switch
+                {
+                    1 => WrapTransaction(transaction),
+                    2 => Generated.Ogmios.NextTransactionResponseEntity.NextTransactionResponse.RequiredTransaction.TransactionEntity.Null,
+                    _ => Generated.Ogmios.NextTransactionResponseEntity.NextTransactionResponse.RequiredTransaction.TransactionEntity.Null
+                };
+            });
+
+        handlers
+            .Setup(x => x.OnSnapshotAcquiredAsync(It.IsAny<Generated.Slot>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        handlers
+            .Setup(x => x.OnTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var service = new MemoryPoolMonitoringClientService(mempoolService.Object);
+
+        await service.RunAsync(
+            CreateInteractionContext(),
+            handlers.Object,
+            cancellationTokenSource.Token);
+
+        handlers.Verify(x => x.OnTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()), Times.Once);
+        mempoolService.Verify(x => x.AcquireMempoolAsync(It.IsAny<InteractionContext>(), It.IsAny<CancellationToken>(), It.IsAny<MirrorOptions?>()), Times.AtLeast(2));
+        Assert.Equal(2, nextCall);
+    }
+
+    [Fact]
+    public async Task RunAsync_DeduplicatesTransactionsWhenEnabled()
+    {
+        var mempoolService = new Mock<IMemoryPoolMonitoringService>();
+        var handlers = new Mock<IMemoryPoolMonitoringMessageHandlers>();
+        var slot = Generated.Slot.ParseValue("99");
+        var transaction = CreateSampleTransaction("duplicate-tx");
+        var cancellationTokenSource = new CancellationTokenSource();
+        var acquireCount = 0;
+        var nextCall = 0;
+
+        mempoolService
+            .Setup(x => x.AcquireMempoolAsync(It.IsAny<InteractionContext>(), It.IsAny<CancellationToken>(), It.IsAny<MirrorOptions?>()))
+            .ReturnsAsync(Generated.Ogmios.AcquireMempoolResponse.RequiredAcquiredAndSlot.Create(
+                acquired: Generated.Ogmios.AcquireMempoolResponse.RequiredAcquiredAndSlot.AcquiredEntity.EnumValues.Mempool,
+                slot: slot))
+            .Callback(() =>
+            {
+                acquireCount++;
+                if (acquireCount > 1)
+                {
+                    cancellationTokenSource.Cancel();
+                }
+            });
+
+        mempoolService
+            .Setup(x => x.NextTransactionAsync(It.IsAny<InteractionContext>(), It.IsAny<CancellationToken>(), It.IsAny<MirrorOptions?>()))
+            .ReturnsAsync(() =>
+            {
+                nextCall++;
+                return nextCall switch
+                {
+                    1 or 2 => WrapTransaction(transaction),
+                    _ => Generated.Ogmios.NextTransactionResponseEntity.NextTransactionResponse.RequiredTransaction.TransactionEntity.Null
+                };
+            });
+
+        handlers
+            .Setup(x => x.OnSnapshotAcquiredAsync(It.IsAny<Generated.Slot>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        handlers
+            .Setup(x => x.OnTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var service = new MemoryPoolMonitoringClientService(mempoolService.Object);
+
+        await service.RunAsync(
+            CreateInteractionContext(),
+            handlers.Object,
+            cancellationTokenSource.Token,
+            new MemoryPoolMonitoringClientOptions { DeduplicateTransactions = true });
+
+        handlers.Verify(x => x.OnTransactionAsync(It.IsAny<Transaction>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Equal(3, nextCall);
+    }
+
+    [Fact]
+    public async Task DrainSnapshotExtension_InvokesCallbackUntilNull()
+    {
+        var mempoolService = new Mock<IMemoryPoolMonitoringService>();
+        var transaction = CreateSampleTransaction("drain-tx");
+        var nextCall = 0;
+        var observed = 0;
+
+        mempoolService
+            .Setup(x => x.NextTransactionAsync(It.IsAny<InteractionContext>(), It.IsAny<CancellationToken>(), It.IsAny<MirrorOptions?>()))
+            .ReturnsAsync(() =>
+            {
+                nextCall++;
+                return nextCall == 1 ? WrapTransaction(transaction) : Generated.Ogmios.NextTransactionResponseEntity.NextTransactionResponse.RequiredTransaction.TransactionEntity.Null;
+            });
+
+        await mempoolService.Object.DrainSnapshotAsync(
+            CreateInteractionContext(),
+            (_, _) =>
+            {
+                observed++;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.Equal(1, observed);
+        Assert.Equal(2, nextCall);
+    }
+
+    private static Generated.Ogmios.NextTransactionResponseEntity.NextTransactionResponse.RequiredTransaction.TransactionEntity WrapTransaction(Transaction transaction)
+    {
+        return Generated.Ogmios.NextTransactionResponseEntity.NextTransactionResponse.RequiredTransaction.TransactionEntity.FromAny(
+            JsonAny.CreateFromSerializedInstance(transaction));
+    }
+
+    private static Transaction CreateSampleTransaction(string idSeed)
+    {
+        return Transaction.Create(
+            id: DigestBlake2b256.FromAny(idSeed),
+            inputs: Transaction.InputsTransactionOutputRefArray.Create(items: []),
+            outputs: Transaction.TransactionOutputArray.Create(items: []),
+            signatories: Transaction.SignatoryArray.Create(items: []),
+            spends: InputSource.EnumValues.Inputs,
+            fee: ValueAdaOnly.Create(ValueAdaOnly.RequiredLovelace.Parse("1")));
+    }
+
+    private static InteractionContext CreateInteractionContext()
+    {
+        return new InteractionContext
+        {
+            StartingPoint = new StartingPointConfiguration { StartingPointIdOrOrigin = "origin" },
+            Connection = new Connection
+            {
+                AddressHttp = new Uri("http://localhost:8080"),
+                AddressWebSocket = new Uri("ws://localhost:8080"),
+                Host = "localhost",
+                Port = 8080
+            },
+            Socket = Mock.Of<IClientWebSocket>()
+        };
+    }
+}

--- a/src/Ogmios.Tests/MemoryPoolMonitoring/MemoryPoolMonitoringTests.cs
+++ b/src/Ogmios.Tests/MemoryPoolMonitoring/MemoryPoolMonitoringTests.cs
@@ -46,6 +46,7 @@ public class MempoolMonitoringClientTests
         var interactionContextInvalidPort = CreateMockInteractionContext(port: 1111);
 
         var mockWebSocketService = new Mock<IWebSocketService>();
+        mockWebSocketService.Setup(x => x.SendAndWaitForResponseBytesAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<IClientWebSocket>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(new WebSocketException("Simulated connection failure"));
         mockWebSocketService.Setup(x => x.SendAndWaitForResponseBytesAsync(It.IsAny<string>(), It.IsAny<IClientWebSocket>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(new WebSocketException("Simulated connection failure"));
 
         var service = new MemoryPoolMonitoringService(mockWebSocketService.Object);
@@ -219,12 +220,21 @@ public class MempoolMonitoringClientTests
 
     private static void SetupBytesResponse(Mock<IWebSocketService> mockWebSocketService, string responseJson)
     {
+        var responseBytes = Encoding.UTF8.GetBytes(responseJson);
+
+        mockWebSocketService.Setup(x => x.SendAndWaitForResponseBytesAsync(
+                It.IsAny<ReadOnlyMemory<byte>>(),
+                It.IsAny<IClientWebSocket>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(responseBytes);
+
         mockWebSocketService.Setup(x => x.SendAndWaitForResponseBytesAsync(
                 It.IsAny<string>(),
                 It.IsAny<IClientWebSocket>(),
                 It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Encoding.UTF8.GetBytes(responseJson));
+            .ReturnsAsync(responseBytes);
     }
 
     private static InteractionContext CreateMockInteractionContext(string host = "localhost", int port = 8080)

--- a/src/Ogmios.Tests/MemoryPoolMonitoring/MemoryPoolMonitoringTests.cs
+++ b/src/Ogmios.Tests/MemoryPoolMonitoring/MemoryPoolMonitoringTests.cs
@@ -1,4 +1,5 @@
 using System.Net.WebSockets;
+using System.Text;
 using Corvus.Json;
 using Moq;
 using Ogmios.Domain;
@@ -45,7 +46,7 @@ public class MempoolMonitoringClientTests
         var interactionContextInvalidPort = CreateMockInteractionContext(port: 1111);
 
         var mockWebSocketService = new Mock<IWebSocketService>();
-        mockWebSocketService.Setup(x => x.SendAndWaitForResponseAsync(It.IsAny<string>(), It.IsAny<IClientWebSocket>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(new WebSocketException("Simulated connection failure"));
+        mockWebSocketService.Setup(x => x.SendAndWaitForResponseBytesAsync(It.IsAny<string>(), It.IsAny<IClientWebSocket>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(new WebSocketException("Simulated connection failure"));
 
         var service = new MemoryPoolMonitoringService(mockWebSocketService.Object);
 
@@ -67,12 +68,7 @@ public class MempoolMonitoringClientTests
         var mockWebSocketService = new Mock<IWebSocketService>();
 
         var validResponseJson = Generated.Ogmios.AcquireMempoolResponse.Create(jsonrpc: Generated.Ogmios.AcquireMempoolResponse.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.AcquireMempoolResponse.MethodEntity.EnumValues.AcquireMempool, result: Generated.Ogmios.AcquireMempoolResponse.RequiredAcquiredAndSlot.Create(acquired: Generated.Ogmios.AcquireMempoolResponse.RequiredAcquiredAndSlot.AcquiredEntity.EnumValues.Mempool, slot: Generated.Slot.ParseValue(slot)));
-        mockWebSocketService.Setup(x => x.SendAndWaitForResponseAsync(
-                It.IsAny<string>(),
-                It.IsAny<IClientWebSocket>(),
-                It.IsAny<int>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(validResponseJson.AsJsonElement.ToString());
+        SetupBytesResponse(mockWebSocketService, validResponseJson.AsJsonElement.ToString());
 
         var service = new MemoryPoolMonitoringService(mockWebSocketService.Object);
 
@@ -93,12 +89,7 @@ public class MempoolMonitoringClientTests
         var service = new MemoryPoolMonitoringService(mockWebSocketService.Object);
 
         var hasTransactionResponseJson = Generated.Ogmios.HasTransactionResponseEntity.HasTransactionResponse.Create(jsonrpc: Generated.Ogmios.HasTransactionResponseEntity.HasTransactionResponse.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.HasTransactionResponseEntity.HasTransactionResponse.MethodEntity.EnumValues.HasTransaction, result: false);
-        mockWebSocketService.Setup(x => x.SendAndWaitForResponseAsync(
-                     It.IsAny<string>(),
-                     It.IsAny<IClientWebSocket>(),
-                     It.IsAny<int>(),
-                     It.IsAny<CancellationToken>()))
-                 .ReturnsAsync(hasTransactionResponseJson.AsJsonElement.ToString());
+        SetupBytesResponse(mockWebSocketService, hasTransactionResponseJson.AsJsonElement.ToString());
 
         // Act
         var exists = await service.HasTransactionAsync(interactionContext, "4f539156bfbefc070a3b61cad3d1cedab3050e2b2a62f0ffe16a43eb0edc1ce8", CancellationToken.None);
@@ -118,12 +109,7 @@ public class MempoolMonitoringClientTests
 
 
         var hasTransactionResponseJson = Generated.Ogmios.MustAcquireMempoolFirst.Create(error: Generated.Ogmios.MustAcquireMempoolFirst.MustAcquireAMempoolSnapshotPriorToPerformingAnyQuery.Create(code: 4000, message: "You must acquire a mempool snapshot prior to accessing it."), jsonrpc: Generated.Ogmios.MustAcquireMempoolFirst.JsonrpcEntity.EnumValues.Value20, method: Generated.Ogmios.MustAcquireMempoolFirst.MethodEntity.EnumValues.HasTransaction);
-        mockWebSocketService.Setup(x => x.SendAndWaitForResponseAsync(
-                     It.IsAny<string>(),
-                     It.IsAny<IClientWebSocket>(),
-                     It.IsAny<int>(),
-                     It.IsAny<CancellationToken>()))
-                 .ReturnsAsync(hasTransactionResponseJson.AsJsonElement.ToString());
+        SetupBytesResponse(mockWebSocketService, hasTransactionResponseJson.AsJsonElement.ToString());
 
         // Act & Assert
         await Assert.ThrowsAsync<MustAcquireMempoolFirstException>(() => service.HasTransactionAsync(interactionContext, "4f539156bfbefc070a3b61cad3d1cedab3050e2b2a62f0ffe16a43eb0edc1ce8", CancellationToken.None));
@@ -142,12 +128,7 @@ public class MempoolMonitoringClientTests
             method: Generated.Ogmios.NextTransactionResponseEntity.NextTransactionResponse.MethodEntity.EnumValues.NextTransaction,
             result: Generated.Ogmios.NextTransactionResponseEntity.NextTransactionResponse.RequiredTransaction.Null
         );
-        mockWebSocketService.Setup(x => x.SendAndWaitForResponseAsync(
-                It.IsAny<string>(),
-                It.IsAny<IClientWebSocket>(),
-                It.IsAny<int>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(nextTransactionResponseJson.AsJsonElement.ToString());
+        SetupBytesResponse(mockWebSocketService, nextTransactionResponseJson.AsJsonElement.ToString());
 
         var service = new MemoryPoolMonitoringService(mockWebSocketService.Object);
 
@@ -175,12 +156,7 @@ public class MempoolMonitoringClientTests
             jsonrpc: Generated.Ogmios.MustAcquireMempoolFirst.JsonrpcEntity.EnumValues.Value20,
             method: Generated.Ogmios.MustAcquireMempoolFirst.MethodEntity.EnumValues.NextTransaction
         );
-        mockWebSocketService.Setup(x => x.SendAndWaitForResponseAsync(
-                It.IsAny<string>(),
-                It.IsAny<IClientWebSocket>(),
-                It.IsAny<int>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(nextTransactionErrorResponseJson.AsJsonElement.ToString());
+        SetupBytesResponse(mockWebSocketService, nextTransactionErrorResponseJson.AsJsonElement.ToString());
 
         var service = new MemoryPoolMonitoringService(mockWebSocketService.Object);
 
@@ -203,12 +179,7 @@ public class MempoolMonitoringClientTests
             result: Generated.Ogmios.MempoolSizeAndCapacity.Create(currentSize: Generated.NumberOfBytes.Create(0), maxCapacity: Generated.NumberOfBytes.Create(1000000), transactions: Generated.Ogmios.MempoolSizeAndCapacity.RequiredCountEntity.Create(Generated.UInt32.ParseValue("5")))
         );
 
-        mockWebSocketService.Setup(x => x.SendAndWaitForResponseAsync(
-                It.IsAny<string>(),
-                It.IsAny<IClientWebSocket>(),
-                It.IsAny<int>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(mempoolSizeResponseJson.AsJsonElement.ToString());
+        SetupBytesResponse(mockWebSocketService, mempoolSizeResponseJson.AsJsonElement.ToString());
 
         var service = new MemoryPoolMonitoringService(mockWebSocketService.Object);
 
@@ -237,18 +208,23 @@ public class MempoolMonitoringClientTests
             jsonrpc: Generated.Ogmios.MustAcquireMempoolFirst.JsonrpcEntity.EnumValues.Value20,
             method: Generated.Ogmios.MustAcquireMempoolFirst.MethodEntity.EnumValues.SizeOfMempool
         );
-        mockWebSocketService.Setup(x => x.SendAndWaitForResponseAsync(
-                It.IsAny<string>(),
-                It.IsAny<IClientWebSocket>(),
-                It.IsAny<int>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(mempoolSizeErrorResponseJson.AsJsonElement.ToString());
+        SetupBytesResponse(mockWebSocketService, mempoolSizeErrorResponseJson.AsJsonElement.ToString());
 
         var service = new MemoryPoolMonitoringService(mockWebSocketService.Object);
 
         // Act & Assert
         await Assert.ThrowsAsync<MustAcquireMempoolFirstException>(() =>
             service.SizeOfMempoolAsync(interactionContext, CancellationToken.None));
+    }
+
+    private static void SetupBytesResponse(Mock<IWebSocketService> mockWebSocketService, string responseJson)
+    {
+        mockWebSocketService.Setup(x => x.SendAndWaitForResponseBytesAsync(
+                It.IsAny<string>(),
+                It.IsAny<IClientWebSocket>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Encoding.UTF8.GetBytes(responseJson));
     }
 
     private static InteractionContext CreateMockInteractionContext(string host = "localhost", int port = 8080)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the planned performance improvements for consumers using `AddOgmiosServices()` directly. All changes are transparent to existing public APIs — same `ResumeAsync` signature, same `IMemoryPoolMonitoringService` methods.

## Changes

### Chain synchronization
- **`maxBlocksPerSecond` is now enforced** when replenishing the pipelined `nextBlock` window after each processed block (`<= 0` = no limit).
- **`ArrayPool<byte>`** for WebSocket receive buffers and queued block messages (`PooledWebSocketMessage`), reducing GC pressure during catch-up sync.
- **Cached `nextBlock` JSON template** in `BlockService` — only the request `id` is encoded per call instead of full Corvus JSON serialization.

### Mempool monitoring
- **UTF-8 parse path** — mempool RPC responses are parsed from bytes via `SendAndWaitForResponseBytesAsync`, avoiding intermediate UTF-16 strings.
- **Method-specific timeouts** via `WebSocketTimeouts`:
  - `MempoolAcquire` = infinite (matches Ogmios blocking acquire semantics)
  - `MempoolQuery` = 5s default for next/has/size/release

### Shared WebSocket layer
- Added `SendMessageAsync(ReadOnlyMemory<byte>)`, `ReceiveMessageBytesAsync`, and `SendAndWaitForResponseBytesAsync`.
- Timeout resolution: `0` → 5s default; `-1` (`Infinite`) → no client timeout.
- Existing string-based methods delegate to the byte paths for consistency.

## Testing
- All 48 `Ogmios.Tests` pass
- All 4 `Ogmios.Example.Worker.Tests` pass
- Added `WebSocketServiceTests` for timeout resolution
- Updated mempool unit tests to mock the byte response path

## Consumer notes
- No DI registration changes required.
- Chain sync handlers should still return quickly; throttling protects downstream overload during catch-up.
- Use separate `InteractionContext` instances when running chain sync and mempool concurrently.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65e655f7-1bb9-44f6-beb9-189d054f9e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65e655f7-1bb9-44f6-beb9-189d054f9e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

