### PR TITLE
Chain sync and mempool performance improvements + buffer lifetime fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,10 @@ The `OgmiosWorker` is a background service that demonstrates how **OgmiosDotnetC
 
 ### Performance notes
 
-- **Replenish `nextBlock` before handler execution** so the pipelined window stays full during slow handlers
-- **Ordered handler queues** (capacity 2000) for chain sync and mempool orchestrator — parsing/RPC continues while handlers run
-- **Pre-serialized mempool RPC bodies** on the hot path (acquire, nextTransaction, size, release)
-- **Zero-allocation `nextBlock` requests** when no custom JSON-RPC id is required
-- **Single-copy WebSocket receive** for chain sync frames
+- Handlers run on bounded ordered queues (default capacity 2000) so RPC/parsing continues during slow consumer work.
+- `nextBlock` pipeline replenishment happens before handler dispatch; static JSON-RPC body when no custom id is needed.
+- Mempool hot-path RPCs use pre-serialized UTF-8 request bodies.
+- Use separate `InteractionContext` instances per concurrent Ogmios protocol.
 
 See [Chain Synchronization](src/Ogmios.Services/ChainSynchronization/docs/README.md) and [Memory Pool Monitoring](src/Ogmios.Services/MemoryPoolMonitoring/docs/README.md) for details.
 

--- a/src/Ogmios.Services/ChainSynchronization/BlockService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/BlockService.cs
@@ -51,49 +51,64 @@ public class BlockService(IWebSocketService webSocketService, ILogger<BlockServi
         await DispatchParsedBlockAsync(result, messageHandlers).ConfigureAwait(false);
     }
 
-    public async ValueTask EnqueueBlockHandlersAsync(ReadOnlyMemory<byte> utf8Response, ChannelWriter<ChainSyncBlockWork> writer, CancellationToken cancellationToken = default)
+    public async ValueTask EnqueueBlockHandlersAsync(PooledWebSocketMessage response, ChannelWriter<ChainSyncBlockWork> writer, CancellationToken cancellationToken = default)
     {
-        if (utf8Response.Length == 0)
+        if (response.Length == 0)
         {
+            response.Return();
             return;
         }
 
-        var result = ParsedValue<Generated.Ogmios.NextBlockResponse>.Parse(utf8Response);
-        await EnqueueParsedBlockAsync(result, writer, cancellationToken).ConfigureAwait(false);
+        var result = ParsedValue<Generated.Ogmios.NextBlockResponse>.Parse(response.Memory);
+        await EnqueueParsedBlockAsync(result, response, writer, cancellationToken).ConfigureAwait(false);
     }
 
     private async Task DispatchParsedBlockAsync(ParsedValue<Generated.Ogmios.NextBlockResponse> result, IChainSynchronizationMessageHandlers messageHandlers)
     {
-        if (!TryCreateBlockWork(result, out var work))
+        if (!result.Instance.Result.TryGetProperty("direction", out var direction))
         {
             return;
         }
 
-        switch (work)
+        switch ((string)direction.AsString)
         {
-            case ChainSyncRollBackwardWork rollback:
-                await messageHandlers.RollBackwardHandler(rollback.Point, rollback.Tip).ConfigureAwait(false);
+            case "backward":
+                var rollBackward = result.Instance.Result.AsRollBackward;
+                await messageHandlers.RollBackwardHandler(rollBackward.Point, rollBackward.Tip).ConfigureAwait(false);
                 break;
-            case ChainSyncRollForwardWork forward:
-                await messageHandlers.RollForwardHandler(forward.Block, forward.BlockType, forward.Tip).ConfigureAwait(false);
+
+            case "forward":
+                var block = result.Instance.Result.AsRollForward.Block;
+                if (block.HasProperty("height") && block.TryGetProperty("height", out _) && block.HasProperty("type") && block.TryGetProperty("type", out var type))
+                {
+                    var blocktype = (string)type.AsString ?? "Unknown type";
+                    await messageHandlers.RollForwardHandler(block, blocktype, result.Instance.Result.AsRollForward.Tip).ConfigureAwait(false);
+                }
+
+                break;
+
+            default:
+                _logger?.LogDebug("Unknown or unsupported block direction: {Direction}", direction.AsString);
                 break;
         }
     }
 
     private async ValueTask EnqueueParsedBlockAsync(
         ParsedValue<Generated.Ogmios.NextBlockResponse> result,
+        PooledWebSocketMessage response,
         ChannelWriter<ChainSyncBlockWork> writer,
         CancellationToken cancellationToken)
     {
-        if (!TryCreateBlockWork(result, out var work))
+        if (!TryCreateBlockWork(result, response, out var work))
         {
+            response.Return();
             return;
         }
 
         await writer.WriteAsync(work, cancellationToken).ConfigureAwait(false);
     }
 
-    private bool TryCreateBlockWork(ParsedValue<Generated.Ogmios.NextBlockResponse> result, out ChainSyncBlockWork work)
+    private bool TryCreateBlockWork(ParsedValue<Generated.Ogmios.NextBlockResponse> result, PooledWebSocketMessage response, out ChainSyncBlockWork work)
     {
         work = null!;
 
@@ -106,7 +121,7 @@ public class BlockService(IWebSocketService webSocketService, ILogger<BlockServi
         {
             case "backward":
                 var rollBackward = result.Instance.Result.AsRollBackward;
-                work = new ChainSyncRollBackwardWork(rollBackward.Point, rollBackward.Tip);
+                work = new ChainSyncRollBackwardWork(response, rollBackward.Point, rollBackward.Tip);
                 return true;
 
             case "forward":
@@ -114,7 +129,7 @@ public class BlockService(IWebSocketService webSocketService, ILogger<BlockServi
                 if (block.HasProperty("height") && block.TryGetProperty("height", out _) && block.HasProperty("type") && block.TryGetProperty("type", out var type))
                 {
                     var blocktype = (string)type.AsString ?? "Unknown type";
-                    work = new ChainSyncRollForwardWork(block, blocktype, result.Instance.Result.AsRollForward.Tip);
+                    work = new ChainSyncRollForwardWork(response, block, blocktype, result.Instance.Result.AsRollForward.Tip);
                     return true;
                 }
 

--- a/src/Ogmios.Services/ChainSynchronization/ChainSyncBlockWork.cs
+++ b/src/Ogmios.Services/ChainSynchronization/ChainSyncBlockWork.cs
@@ -4,10 +4,14 @@ namespace Ogmios.Services.ChainSynchronization;
 
 /// <summary>
 /// Ordered block event dispatched to <see cref="IChainSynchronizationMessageHandlers"/>.
+/// Retains the pooled WebSocket response buffer until handler execution completes.
 /// </summary>
-public abstract class ChainSyncBlockWork;
+public abstract class ChainSyncBlockWork(PooledWebSocketMessage responseBuffer)
+{
+    public PooledWebSocketMessage ResponseBuffer { get; } = responseBuffer;
+}
 
-public sealed class ChainSyncRollForwardWork(Block block, string blockType, Tip tip) : ChainSyncBlockWork
+public sealed class ChainSyncRollForwardWork(PooledWebSocketMessage responseBuffer, Block block, string blockType, Tip tip) : ChainSyncBlockWork(responseBuffer)
 {
     public Block Block { get; } = block;
 
@@ -16,7 +20,7 @@ public sealed class ChainSyncRollForwardWork(Block block, string blockType, Tip 
     public Tip Tip { get; } = tip;
 }
 
-public sealed class ChainSyncRollBackwardWork(Generated.Ogmios.PointOrOrigin point, Generated.Ogmios.TipOrOrigin tip) : ChainSyncBlockWork
+public sealed class ChainSyncRollBackwardWork(PooledWebSocketMessage responseBuffer, Generated.Ogmios.PointOrOrigin point, Generated.Ogmios.TipOrOrigin tip) : ChainSyncBlockWork(responseBuffer)
 {
     public Generated.Ogmios.PointOrOrigin Point { get; } = point;
 

--- a/src/Ogmios.Services/ChainSynchronization/ChainSynchronizationClientService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/ChainSynchronizationClientService.cs
@@ -179,14 +179,11 @@ namespace Ogmios.Services.ChainSynchronization
 
                     try
                     {
-                        await _blockService.EnqueueBlockHandlersAsync(message.Memory, handlerWriter, cancellationToken).ConfigureAwait(false);
+                        await _blockService.EnqueueBlockHandlersAsync(message, handlerWriter, cancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
                         _logger?.LogError(ex, "Error enqueueing block handler work.");
-                    }
-                    finally
-                    {
                         message.Return();
                     }
                 }
@@ -222,6 +219,10 @@ namespace Ogmios.Services.ChainSynchronization
                     catch (Exception ex)
                     {
                         _logger?.LogError(ex, "Error executing chain sync handler.");
+                    }
+                    finally
+                    {
+                        work.ResponseBuffer.Return();
                     }
                 }
             }

--- a/src/Ogmios.Services/ChainSynchronization/IBlockService.cs
+++ b/src/Ogmios.Services/ChainSynchronization/IBlockService.cs
@@ -10,5 +10,5 @@ public interface IBlockService
 
     Task HandleNextBlockAsync(ReadOnlyMemory<byte> utf8Response, IChainSynchronizationMessageHandlers messageHandlers);
 
-    ValueTask EnqueueBlockHandlersAsync(ReadOnlyMemory<byte> utf8Response, System.Threading.Channels.ChannelWriter<ChainSyncBlockWork> writer, CancellationToken cancellationToken = default);
+    ValueTask EnqueueBlockHandlersAsync(PooledWebSocketMessage response, System.Threading.Channels.ChannelWriter<ChainSyncBlockWork> writer, CancellationToken cancellationToken = default);
 }

--- a/src/Ogmios.Services/Ogmios.Services.csproj
+++ b/src/Ogmios.Services/Ogmios.Services.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Ogmios.Services</RootNamespace>
     
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>6.14.0.3</Version>
+    <Version>6.14.0.4</Version>
     <Authors>Dave B</Authors>
     <PackageId>OgmiosDotnetClient.Services</PackageId>
     <Description>A set of services and extensions for integrating Ogmios functionality, including chain synchronization, memory pool monitoring, transaction submission, transaction evaluation, ledger state queries, and server health monitoring.</Description>

--- a/src/Ogmios.Tests/ChainSynchronization/BlockServiceBufferLifetimeTests.cs
+++ b/src/Ogmios.Tests/ChainSynchronization/BlockServiceBufferLifetimeTests.cs
@@ -1,0 +1,77 @@
+using System.Buffers;
+using System.Net.WebSockets;
+using System.Text;
+using System.Threading.Channels;
+using Corvus.Json;
+using Generated;
+using Ogmios.Domain;
+using Ogmios.Services.ChainSynchronization;
+using static Generated.Ogmios;
+
+namespace Ogmios.Tests.ChainSynchronization;
+
+public class BlockServiceBufferLifetimeTests
+{
+    private readonly BlockService _blockService = new(new WebSocketService());
+
+    [Fact]
+    public async Task EnqueueBlockHandlersAsync_AttachesResponseBufferToWork()
+    {
+        var channel = Channel.CreateUnbounded<ChainSyncBlockWork>();
+        var message = CreatePooledForwardResponse();
+
+        await _blockService.EnqueueBlockHandlersAsync(message, channel.Writer);
+        channel.Writer.TryComplete();
+
+        var work = await channel.Reader.ReadAsync();
+        var forward = Assert.IsType<ChainSyncRollForwardWork>(work);
+
+        Assert.Same(message.Buffer, forward.ResponseBuffer.Buffer);
+        forward.ResponseBuffer.Return();
+    }
+
+    private static PooledWebSocketMessage CreatePooledForwardResponse()
+    {
+        var response = NextBlockResponse.Create(
+            NextBlockResponse.JsonrpcEntity.EnumValues.Value20,
+            NextBlockResponse.MethodEntity.EnumValues.NextBlock,
+            NextBlockResponse.ResultEntity.RollForward.Create(
+                BlockPraos.FromProperties(new Dictionary<JsonPropertyName, JsonAny>
+                {
+                    { new JsonPropertyName("height"), JsonNumber.ParseValue("115545883") },
+                    { new JsonPropertyName("type"), JsonAny.FromAny(BlockPraos.TypeEntity.EnumValues.Praos) }
+                }),
+                NextBlockResponse.ResultEntity.RollForward.DirectionEntity.EnumValues.Forward,
+                NextBlockResponse.ResultEntity.RollForward.DefaultInstance.Tip));
+
+        var json = response.AsJsonElement.ToString() ?? string.Empty;
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var rented = ArrayPool<byte>.Shared.Rent(bytes.Length);
+        Buffer.BlockCopy(bytes, 0, rented, 0, bytes.Length);
+
+        return new PooledWebSocketMessage(rented, bytes.Length, CreateDummyContext());
+    }
+
+    private static InteractionContext CreateDummyContext()
+    {
+        return new InteractionContext
+        {
+            ConnectionName = "TestConnection",
+            StartingPoint = new StartingPointConfiguration
+            {
+                StartingPointIdOrOrigin = "origin",
+                StartingPointSlot = 0
+            },
+            Connection = new Connection
+            {
+                Host = "localhost",
+                Port = 8080,
+                Tls = false,
+                MaxPayload = 1024,
+                AddressHttp = new Uri("http://localhost:8080"),
+                AddressWebSocket = new Uri("ws://localhost:8080")
+            },
+            Socket = new Moq.Mock<IClientWebSocket>().Object
+        };
+    }
+}

--- a/src/Ogmios.Tests/ChainSynchronization/ChainSynchronizationClientServiceTests.cs
+++ b/src/Ogmios.Tests/ChainSynchronization/ChainSynchronizationClientServiceTests.cs
@@ -182,7 +182,10 @@ namespace Ogmios.Tests.ChainSynchronization
 
             // Assert
             _mockBlockService.Verify(
-                x => x.EnqueueBlockHandlersAsync(It.Is<ReadOnlyMemory<byte>>(b => Encoding.UTF8.GetString(b.ToArray()) == message), It.IsAny<System.Threading.Channels.ChannelWriter<ChainSyncBlockWork>>(), It.IsAny<CancellationToken>()),
+                x => x.EnqueueBlockHandlersAsync(
+                    It.Is<PooledWebSocketMessage>(m => Encoding.UTF8.GetString(m.Memory.ToArray()) == message),
+                    It.IsAny<System.Threading.Channels.ChannelWriter<ChainSyncBlockWork>>(),
+                    It.IsAny<CancellationToken>()),
                 Times.Once,
                 "Expected EnqueueBlockHandlersAsync to be called once with the correct message."
             );
@@ -225,10 +228,10 @@ namespace Ogmios.Tests.ChainSynchronization
                 });
 
             // Setup the message handlers to log the order of message processing
-            _mockBlockService.Setup(x => x.EnqueueBlockHandlersAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<ChannelWriter<ChainSyncBlockWork>>(), It.IsAny<CancellationToken>()))
-                .Callback<ReadOnlyMemory<byte>, ChannelWriter<ChainSyncBlockWork>, CancellationToken>((bytes, _, _) =>
+            _mockBlockService.Setup(x => x.EnqueueBlockHandlersAsync(It.IsAny<PooledWebSocketMessage>(), It.IsAny<ChannelWriter<ChainSyncBlockWork>>(), It.IsAny<CancellationToken>()))
+                .Callback<PooledWebSocketMessage, ChannelWriter<ChainSyncBlockWork>, CancellationToken>((message, _, _) =>
                 {
-                    messageLog.Add(Encoding.UTF8.GetString(bytes.Span));
+                    messageLog.Add(Encoding.UTF8.GetString(message.Memory.Span));
                 })
                 .Returns(ValueTask.CompletedTask);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Performance improvements for chain sync and mempool consumers using `AddOgmiosServices()`.

### Bug fix (6.14.0.4)

Fixed `InvalidOperationException: Operation is not valid due to the current state of the object` when enumerating block transactions in async chain sync handlers. Corvus `Block`/`Transaction` types reference the pooled WebSocket receive buffer; the handler queue was returning that buffer to `ArrayPool` immediately after enqueue, before handlers ran. Buffer ownership is now transferred to `ChainSyncBlockWork` and returned after handler execution.

### Chain sync throughput

- Enforce `maxBlocksPerSecond` when replenishing the `nextBlock` pipeline
- Replenish pipeline **before** handler dispatch
- Ordered handler queue (capacity 2000) so parsing/RPC continues during slow handlers
- `ArrayPool<byte>` for WebSocket receive frames
- Single-copy WebSocket receive (no MemoryStream double copy)
- Static pre-serialized `nextBlock` JSON when no custom JSON-RPC id

### Mempool throughput

- `IMemoryPoolMonitoringClientService` orchestrator (acquire → drain-all → repeat) with dedup
- `MemoryPoolMonitoringExtensions` (`DrainSnapshotAsync`, `MonitorAsync`)
- Pre-serialized UTF-8 mempool RPC bodies on hot path
- Ordered handler queue for mempool transaction dispatch

### Package versions

| Package | Version |
|---------|---------|
| OgmiosDotnetClient.Domain | 6.14.0.2 |
| OgmiosDotnetClient.Schema | 6.14.0.2 |
| OgmiosDotnetClient.Services | **6.14.0.4** |

## Test plan

- [x] `dotnet test OgmiosDotnet.sln` — 56 tests passing
- [x] Added `BlockServiceBufferLifetimeTests` for pooled buffer ownership on queued block work

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65e655f7-1bb9-44f6-beb9-189d054f9e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65e655f7-1bb9-44f6-beb9-189d054f9e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

